### PR TITLE
Style refactors

### DIFF
--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -4,10 +4,9 @@ defmodule LiquidVoting.Delegations do
   """
 
   import Ecto.Query, warn: false
-  alias LiquidVoting.Repo
 
-  alias LiquidVoting.Delegations.Delegation
-  alias LiquidVoting.Voting
+  alias __MODULE__.Delegation
+  alias LiquidVoting.{Repo, Voting}
 
   @doc """
   Returns the list of delegations for an organization uuid
@@ -63,8 +62,8 @@ defmodule LiquidVoting.Delegations do
     delegator = Voting.get_participant_by_email!(delegator_email, organization_uuid)
     delegate = Voting.get_participant_by_email!(delegate_email, organization_uuid)
 
-    Delegation
-    |> Repo.get_by!(
+    Repo.get_by!(
+      Delegation,
       delegator_id: delegator.id,
       delegate_id: delegate.id,
       proposal_url: proposal_url,
@@ -90,8 +89,8 @@ defmodule LiquidVoting.Delegations do
     delegator = Voting.get_participant_by_email!(delegator_email, organization_uuid)
     delegate = Voting.get_participant_by_email!(delegate_email, organization_uuid)
 
-    Delegation
-    |> Repo.get_by!(
+    Repo.get_by!(
+      Delegation,
       delegator_id: delegator.id,
       delegate_id: delegate.id,
       organization_uuid: organization_uuid
@@ -152,9 +151,7 @@ defmodule LiquidVoting.Delegations do
       {:error, %Ecto.Changeset{}}
 
   """
-  def delete_delegation(%Delegation{} = delegation) do
-    Repo.delete(delegation)
-  end
+  def delete_delegation(%Delegation{} = delegation), do: Repo.delete(delegation)
 
   @doc """
   Deletes a Delegation.
@@ -168,9 +165,7 @@ defmodule LiquidVoting.Delegations do
       ** (Ecto.NoResultsError)
 
   """
-  def delete_delegation!(%Delegation{} = delegation) do
-    Repo.delete!(delegation)
-  end
+  def delete_delegation!(%Delegation{} = delegation), do: Repo.delete!(delegation)
 
   @doc """
   Returns an `%Ecto.Changeset{}` for tracking delegation changes.
@@ -181,7 +176,5 @@ defmodule LiquidVoting.Delegations do
       %Ecto.Changeset{source: %Delegation{}}
 
   """
-  def change_delegation(%Delegation{} = delegation) do
-    Delegation.changeset(delegation, %{})
-  end
+  def change_delegation(%Delegation{} = delegation), do: Delegation.changeset(delegation, %{})
 end

--- a/lib/liquid_voting/voting.ex
+++ b/lib/liquid_voting/voting.ex
@@ -4,10 +4,9 @@ defmodule LiquidVoting.Voting do
   """
 
   import Ecto.Query, warn: false
-  alias LiquidVoting.Repo
 
-  alias LiquidVoting.Voting.{Vote, Participant}
-  alias LiquidVoting.Delegations
+  alias __MODULE__.{Vote, Participant}
+  alias LiquidVoting.{Repo, Delegations}
   alias LiquidVoting.Delegations.Delegation
 
   @doc """
@@ -25,7 +24,12 @@ defmodule LiquidVoting.Voting do
   """
   def create_vote(attrs \\ %{}) do
     Repo.transaction(fn ->
-      case %Vote{} |> Vote.changeset(attrs) |> Repo.insert() do
+      # TODO: refactor case statements into small functions. 
+
+      %Vote{}
+      |> Vote.changeset(attrs)
+      |> Repo.insert()
+      |> case do
         {:ok, vote} ->
           if delegation =
                Repo.get_by(Delegation,
@@ -160,9 +164,7 @@ defmodule LiquidVoting.Voting do
       {:error, %Ecto.Changeset{}}
 
   """
-  def delete_vote(%Vote{} = vote) do
-    Repo.delete(vote)
-  end
+  def delete_vote(%Vote{} = vote), do: Repo.delete(vote)
 
   @doc """
   Deletes a Vote.
@@ -176,9 +178,7 @@ defmodule LiquidVoting.Voting do
       Ecto.*Error
 
   """
-  def delete_vote!(%Vote{} = vote) do
-    Repo.delete!(vote)
-  end
+  def delete_vote!(%Vote{} = vote), do: Repo.delete!(vote)
 
   @doc """
   Returns an `%Ecto.Changeset{}` for tracking vote changes.
@@ -189,9 +189,7 @@ defmodule LiquidVoting.Voting do
       %Ecto.Changeset{source: %Vote{}}
 
   """
-  def change_vote(%Vote{} = vote) do
-    Vote.changeset(vote, %{})
-  end
+  def change_vote(%Vote{} = vote), do: Vote.changeset(vote, %{})
 
   @doc """
   Returns the list of participants for an organization uuid
@@ -222,10 +220,8 @@ defmodule LiquidVoting.Voting do
       ** (Ecto.NoResultsError)
 
   """
-  def get_participant!(id, organization_uuid) do
-    Participant
-    |> Repo.get_by!(id: id, organization_uuid: organization_uuid)
-  end
+  def get_participant!(id, organization_uuid),
+    do: Repo.get_by!(Participant, id: id, organization_uuid: organization_uuid)
 
   @doc """
   Gets a single participant for an organization uuid by their email
@@ -241,10 +237,8 @@ defmodule LiquidVoting.Voting do
       nil
 
   """
-  def get_participant_by_email(email, organization_uuid) do
-    Participant
-    |> Repo.get_by(email: email, organization_uuid: organization_uuid)
-  end
+  def get_participant_by_email(email, organization_uuid),
+    do: Repo.get_by(Participant, email: email, organization_uuid: organization_uuid)
 
   @doc """
   Gets a single participant for an organization uuid by their email
@@ -260,10 +254,8 @@ defmodule LiquidVoting.Voting do
       ** (Ecto.NoResultsError)
 
   """
-  def get_participant_by_email!(email, organization_uuid) do
-    Participant
-    |> Repo.get_by!(email: email, organization_uuid: organization_uuid)
-  end
+  def get_participant_by_email!(email, organization_uuid),
+    do: Repo.get_by!(Participant, email: email, organization_uuid: organization_uuid)
 
   @doc """
   Creates a participant.
@@ -328,9 +320,7 @@ defmodule LiquidVoting.Voting do
       {:error, %Ecto.Changeset{}}
 
   """
-  def delete_participant(%Participant{} = participant) do
-    Repo.delete(participant)
-  end
+  def delete_participant(%Participant{} = participant), do: Repo.delete(participant)
 
   @doc """
   Returns an `%Ecto.Changeset{}` for tracking participant changes.
@@ -341,7 +331,6 @@ defmodule LiquidVoting.Voting do
       %Ecto.Changeset{source: %Participant{}}
 
   """
-  def change_participant(%Participant{} = participant) do
-    Participant.changeset(participant, %{})
-  end
+  def change_participant(%Participant{} = participant),
+    do: Participant.changeset(participant, %{})
 end

--- a/lib/liquid_voting/voting_results.ex
+++ b/lib/liquid_voting/voting_results.ex
@@ -4,10 +4,9 @@ defmodule LiquidVoting.VotingResults do
   """
 
   import Ecto.Query, warn: false
-  alias LiquidVoting.Repo
-  alias LiquidVoting.Voting
-  alias LiquidVoting.VotingWeight
-  alias LiquidVoting.VotingResults.Result
+
+  alias __MODULE__.Result
+  alias LiquidVoting.{Repo, Voting, VotingWeight}
 
   @doc """
   Creates or updates voting result based on votes
@@ -96,10 +95,8 @@ defmodule LiquidVoting.VotingResults do
       ** (Ecto.NoResultsError)
 
   """
-  def get_result!(id, organization_uuid) do
-    Result
-    |> Repo.get_by!(id: id, organization_uuid: organization_uuid)
-  end
+  def get_result!(id, organization_uuid),
+    do: Repo.get_by!(Result, id: id, organization_uuid: organization_uuid)
 
   @doc """
   Gets a single result by its proposal url and organization_uuid
@@ -115,10 +112,8 @@ defmodule LiquidVoting.VotingResults do
       nil
 
   """
-  def get_result_by_proposal_url(proposal_url, organization_uuid) do
-    Result
-    |> Repo.get_by(proposal_url: proposal_url, organization_uuid: organization_uuid)
-  end
+  def get_result_by_proposal_url(proposal_url, organization_uuid),
+    do: Repo.get_by(Result, proposal_url: proposal_url, organization_uuid: organization_uuid)
 
   @doc """
   Creates a result.

--- a/lib/liquid_voting/voting_weight.ex
+++ b/lib/liquid_voting/voting_weight.ex
@@ -4,9 +4,8 @@ defmodule LiquidVoting.VotingWeight do
   """
 
   import Ecto.Query, warn: false
-  alias LiquidVoting.Repo
 
-  alias LiquidVoting.Voting
+  alias LiquidVoting.{Repo, Voting}
 
   @doc """
   Updates vote weight based on delegations given to voter
@@ -72,7 +71,5 @@ defmodule LiquidVoting.VotingWeight do
   # Base case for the above recursion:
   # 
   # If no delegations left, just return the latest weight
-  defp delegation_weight(_ = [], _, weight) do
-    weight
-  end
+  defp delegation_weight(_ = [], _, weight), do: weight
 end

--- a/lib/liquid_voting_web.ex
+++ b/lib/liquid_voting_web.ex
@@ -23,6 +23,7 @@ defmodule LiquidVotingWeb do
 
       import Plug.Conn
       import LiquidVotingWeb.Gettext
+
       alias LiquidVotingWeb.Router.Helpers, as: Routes
     end
   end
@@ -35,9 +36,9 @@ defmodule LiquidVotingWeb do
 
       # Import convenience functions from controllers
       import Phoenix.Controller, only: [get_flash: 1, get_flash: 2, view_module: 1]
-
       import LiquidVotingWeb.ErrorHelpers
       import LiquidVotingWeb.Gettext
+
       alias LiquidVotingWeb.Router.Helpers, as: Routes
     end
   end
@@ -45,6 +46,7 @@ defmodule LiquidVotingWeb do
   def router do
     quote do
       use Phoenix.Router
+
       import Plug.Conn
       import Phoenix.Controller
     end
@@ -60,7 +62,5 @@ defmodule LiquidVotingWeb do
   @doc """
   When used, dispatch to the appropriate controller/view/etc.
   """
-  defmacro __using__(which) when is_atom(which) do
-    apply(__MODULE__, which, [])
-  end
+  defmacro __using__(which) when is_atom(which), do: apply(__MODULE__, which, [])
 end

--- a/lib/liquid_voting_web/channels/user_socket.ex
+++ b/lib/liquid_voting_web/channels/user_socket.ex
@@ -16,9 +16,7 @@ defmodule LiquidVotingWeb.UserSocket do
   #
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
-  def connect(_params, socket, _connect_info) do
-    {:ok, socket}
-  end
+  def connect(_params, socket, _connect_info), do: {:ok, socket}
 
   # Socket id's are topics that allow you to identify all sockets for a given user:
   #

--- a/lib/liquid_voting_web/resolvers/voting.ex
+++ b/lib/liquid_voting_web/resolvers/voting.ex
@@ -2,13 +2,11 @@ defmodule LiquidVotingWeb.Resolvers.Voting do
   alias LiquidVoting.{Voting, VotingResults}
   alias LiquidVotingWeb.Schema.ChangesetErrors
 
-  def participants(_, _, %{context: %{organization_uuid: organization_uuid}}) do
-    {:ok, Voting.list_participants(organization_uuid)}
-  end
+  def participants(_, _, %{context: %{organization_uuid: organization_uuid}}),
+    do: {:ok, Voting.list_participants(organization_uuid)}
 
-  def participant(_, %{id: id}, %{context: %{organization_uuid: organization_uuid}}) do
-    {:ok, Voting.get_participant!(id, organization_uuid)}
-  end
+  def participant(_, %{id: id}, %{context: %{organization_uuid: organization_uuid}}),
+    do: {:ok, Voting.get_participant!(id, organization_uuid)}
 
   def create_participant(_, args, %{context: %{organization_uuid: organization_uuid}}) do
     args = Map.put(args, :organization_uuid, organization_uuid)
@@ -24,17 +22,14 @@ defmodule LiquidVotingWeb.Resolvers.Voting do
     end
   end
 
-  def votes(_, %{proposal_url: proposal_url}, %{context: %{organization_uuid: organization_uuid}}) do
-    {:ok, Voting.list_votes(proposal_url, organization_uuid)}
-  end
+  def votes(_, %{proposal_url: proposal_url}, %{context: %{organization_uuid: organization_uuid}}),
+    do: {:ok, Voting.list_votes(proposal_url, organization_uuid)}
 
-  def votes(_, _, %{context: %{organization_uuid: organization_uuid}}) do
-    {:ok, Voting.list_votes(organization_uuid)}
-  end
+  def votes(_, _, %{context: %{organization_uuid: organization_uuid}}),
+    do: {:ok, Voting.list_votes(organization_uuid)}
 
-  def vote(_, %{id: id}, %{context: %{organization_uuid: organization_uuid}}) do
-    {:ok, Voting.get_vote!(id, organization_uuid)}
-  end
+  def vote(_, %{id: id}, %{context: %{organization_uuid: organization_uuid}}),
+    do: {:ok, Voting.get_vote!(id, organization_uuid)}
 
   def create_vote(_, %{participant_email: email, proposal_url: _, yes: _} = args, %{
         context: %{organization_uuid: organization_uuid}
@@ -46,24 +41,26 @@ defmodule LiquidVotingWeb.Resolvers.Voting do
          details: ChangesetErrors.error_details(changeset)}
 
       {:ok, participant} ->
-        args = Map.put(args, :organization_uuid, organization_uuid)
-        args = Map.put(args, :participant_id, participant.id)
-        create_vote_with_valid_arguments(args)
+        args
+        |> Map.put(:organization_uuid, organization_uuid)
+        |> Map.put(:participant_id, participant.id)
+        |> create_vote_with_valid_arguments()
     end
   end
 
   def create_vote(_, %{participant_id: _, proposal_url: _, yes: _} = args, %{
         context: %{organization_uuid: organization_uuid}
       }) do
-    args = Map.put(args, :organization_uuid, organization_uuid)
-    create_vote_with_valid_arguments(args)
+    args
+    |> Map.put(:organization_uuid, organization_uuid)
+    |> create_vote_with_valid_arguments()
   end
 
-  def create_vote(_, %{proposal_url: _, yes: _}, _) do
-    {:error,
-     message: "Could not create vote",
-     details: "No participant identifier (id or email) submitted"}
-  end
+  def create_vote(_, %{proposal_url: _, yes: _}, _),
+    do:
+      {:error,
+       message: "Could not create vote",
+       details: "No participant identifier (id or email) submitted"}
 
   defp create_vote_with_valid_arguments(args) do
     case Voting.create_vote(args) do

--- a/lib/liquid_voting_web/resolvers/voting_results.ex
+++ b/lib/liquid_voting_web/resolvers/voting_results.ex
@@ -1,7 +1,6 @@
 defmodule LiquidVotingWeb.Resolvers.VotingResults do
   alias LiquidVoting.VotingResults
 
-  def result(_, %{proposal_url: proposal_url}, %{context: %{organization_uuid: organization_uuid}}) do
-    {:ok, VotingResults.get_result_by_proposal_url(proposal_url, organization_uuid)}
-  end
+  def result(_, %{proposal_url: proposal_url}, %{context: %{organization_uuid: organization_uuid}}),
+      do: {:ok, VotingResults.get_result_by_proposal_url(proposal_url, organization_uuid)}
 end

--- a/lib/liquid_voting_web/views/error_view.ex
+++ b/lib/liquid_voting_web/views/error_view.ex
@@ -10,7 +10,6 @@ defmodule LiquidVotingWeb.ErrorView do
   # By default, Phoenix returns the status message from
   # the template name. For example, "404.json" becomes
   # "Not Found".
-  def template_not_found(template, _assigns) do
-    %{errors: %{detail: Phoenix.Controller.status_message_from_template(template)}}
-  end
+  def template_not_found(template, _assigns),
+    do: %{errors: %{detail: Phoenix.Controller.status_message_from_template(template)}}
 end

--- a/test/liquid_voting/delegations_test.exs
+++ b/test/liquid_voting/delegations_test.exs
@@ -2,7 +2,6 @@ defmodule LiquidVoting.DelegationsTest do
   use LiquidVoting.DataCase
   import LiquidVoting.Factory
 
-  alias LiquidVoting.Voting
   alias LiquidVoting.Delegations
   alias LiquidVoting.Delegations.Delegation
 

--- a/test/liquid_voting/voting_weight_test.exs
+++ b/test/liquid_voting/voting_weight_test.exs
@@ -2,7 +2,7 @@ defmodule LiquidVoting.VotingWeightTest do
   use LiquidVoting.DataCase
 
   import LiquidVoting.Factory
-  
+
   alias LiquidVoting.{Repo, VotingWeight}
 
   describe "update_vote_weight/1 simplest scenario (global delegations)" do

--- a/test/liquid_voting/voting_weight_test.exs
+++ b/test/liquid_voting/voting_weight_test.exs
@@ -1,9 +1,9 @@
 defmodule LiquidVoting.VotingWeightTest do
   use LiquidVoting.DataCase
-  import LiquidVoting.Factory
-  alias LiquidVoting.Repo
 
-  alias LiquidVoting.VotingWeight
+  import LiquidVoting.Factory
+  
+  alias LiquidVoting.{Repo, VotingWeight}
 
   describe "update_vote_weight/1 simplest scenario (global delegations)" do
     test "updates vote weight based on the number of delegations given to voter" do


### PR DESCRIPTION
Closes #59.

Changes I included: 
- use `def func(), do:` syntax for one-line functions
- remove single pipes
- start pipes with raw value and not a function call 
- use pipes instead of reassignment where possible
- use `__MODULE__` where possible
- consolidate aliases under same namespace with `Mod.{ModA, ModB}`

Changes I didn't include (i.e. larger refactoring opportunities).
- doctests, see #63 
- nested control flow (making logic hard to follow) 
- large functions should be broken up into smaller ones doing only one thing
- pattern matching in function heads should be mainly used for control flow 
- module imports spacing, I've left this mostly as is, as it's mostly down to personal preference