### PR TITLE
api#14-add-uuid-column-to-participants-table

### DIFF
--- a/lib/liquid_voting/voting/participant.ex
+++ b/lib/liquid_voting/voting/participant.ex
@@ -20,7 +20,7 @@ defmodule LiquidVoting.Voting.Participant do
   @doc false
   def changeset(participant, attrs) do
     required_fields = [:email, :organization_uuid]
-    all_fields = [:name, :uuid | required_fields]
+    all_fields = [:name | required_fields]
 
     participant
     |> cast(attrs, all_fields)

--- a/lib/liquid_voting/voting/participant.ex
+++ b/lib/liquid_voting/voting/participant.ex
@@ -8,6 +8,7 @@ defmodule LiquidVoting.Voting.Participant do
   schema "participants" do
     field :name, :string
     field :email, EctoFields.Email
+    field :uuid, Ecto.UUID, autogenerate: true
     field :organization_uuid, Ecto.UUID
 
     has_many :votes, Vote
@@ -19,7 +20,7 @@ defmodule LiquidVoting.Voting.Participant do
   @doc false
   def changeset(participant, attrs) do
     required_fields = [:email, :organization_uuid]
-    all_fields = [:name | required_fields]
+    all_fields = [:name, :uuid | required_fields]
 
     participant
     |> cast(attrs, all_fields)

--- a/priv/repo/migrations/20200706113113_add_participant_uuid_to_participants.exs
+++ b/priv/repo/migrations/20200706113113_add_participant_uuid_to_participants.exs
@@ -1,0 +1,9 @@
+defmodule LiquidVoting.Repo.Migrations.AddParticipantUuidToParticipants do
+  use Ecto.Migration
+
+  def change do
+    alter table(:participants) do
+      add :uuid, :uuid
+    end
+  end
+end

--- a/test/liquid_voting/participants_test.exs
+++ b/test/liquid_voting/participants_test.exs
@@ -61,6 +61,11 @@ defmodule LiquidVoting.ParticipantsTest do
       assert participant.name == @valid_attrs[:name]
     end
 
+    test "create_participant/1 with valid data creates a uuid" do
+      assert {:ok, %Participant{} = participant} = Voting.create_participant(@valid_attrs)
+      assert {:ok, _uuid_bitstring} = Ecto.UUID.dump(participant.uuid)
+    end
+
     test "create_participant/1 with missing data returns error changeset" do
       assert {:error, %Ecto.Changeset{}} = Voting.create_participant(@invalid_attrs)
     end


### PR DESCRIPTION
Notes:

Participant changeset doesn't validate uuid as "required field", since we want the uuid to be generated on creation of a participant. Thus, if the uuid is deleted by subsequent changes, that would not be caught. I wonder if this means we should have 2 changesets (one for create, another for update/edit - the latter having uuid as required field).

I have not set the uuid as index, nor unique_index. Currently we have a unique_index of:
```elixir
# api/priv/repo/migrations/20200519150515_update_participant_index_on_email.exs

create unique_index(:participants, [:organization_uuid, :email],  name: :uniq_index_organization_uuid_participant_email)
```

I have also not set the uuid as primary key (currently is set to `id: "participants_pkey" PRIMARY KEY, btree (id) ...`)