### PR TITLE
Implement missing weight recalculation delegations 

### DIFF
--- a/lib/liquid_voting/voting_results.ex
+++ b/lib/liquid_voting/voting_results.ex
@@ -30,6 +30,7 @@ defmodule LiquidVoting.VotingResults do
 
     attrs =
       Enum.reduce(votes, attrs, fn vote, attrs ->
+        #  TODO: this update should be happening on vote creation or delegation creation?
         {:ok, vote} = VotingWeight.update_vote_weight(vote)
 
         if vote.yes do
@@ -58,6 +59,7 @@ defmodule LiquidVoting.VotingResults do
 
   """
   def publish_voting_result_change(proposal_url, organization_id) do
+    # TODO: decouple publishing and result calculation
     result = calculate_result!(proposal_url, organization_id)
 
     Absinthe.Subscription.publish(


### PR DESCRIPTION
Resolves #52.

Implements weight recalculation on: 
- delegation creation for specific proposal
- global delegation creation

Currently this just contains my comments and ideas related to the issue.