### PR TITLE
fix graphiql subscription with interface: :advanced in router.ex

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ docker run -it --rm \
 
 ### Once you're up and running
 
-Point a [GraphiQL app](https://www.electronjs.org/apps/graphiql) to http://localhost:4000/, then configure a `Org-UUID` header:
+Open a GraphiQL window in your browser at http://localhost:4000/graphiql, then configure a `Org-UUID` header:
 
 ```json
 { "Org-UUID": "b7a9cae5-6e3a-48b1-8730-8b5c8d6c9b5a"}
@@ -212,6 +212,6 @@ subscription {
 }
 ```
 
-To see this in action, open a second graphiql window and run `createVote` mutations there, and watch the subscription responses come through on the first one.
+To see this in action, open a second graphiql window in your browser and run `createVote` mutations there, and watch the subscription responses come through on the first one.
 
 With the examples above, the `inFavor` count should be `1`, and `against` should be `2` since `liz@somedomain.com` had a delegation from `nelson@somedomain.com`.

--- a/lib/liquid_voting_web/router.ex
+++ b/lib/liquid_voting_web/router.ex
@@ -12,7 +12,7 @@ defmodule LiquidVotingWeb.Router do
     forward "/graphiql", Absinthe.Plug.GraphiQL,
       schema: LiquidVotingWeb.Schema.Schema,
       socket: LiquidVotingWeb.UserSocket,
-      interface: :simple
+      interface: :advanced
 
     forward "/", Absinthe.Plug, schema: LiquidVotingWeb.Schema.Schema
   end


### PR DESCRIPTION
This addresses issue [#84](https://github.com/liquidvotingio/api/issues/84): 'Graphql subscription not updating' 

Subscriptions will work when the interface is set to `:advanced` in 'router.ex'. It also seems that the graphiQL app doesn't work with subscriptions (no websocket set, even in advanced mode - though maybe this is configurable somehow?), but they work fine in the graphiQL browser window view. I have also edited the readme to include instructions to use the browser, where needed.