### PR TITLE
Add and set global boolean for delegations

### DIFF
--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -116,8 +116,6 @@ defmodule LiquidVoting.Delegations do
   def create_delegation(attrs \\ %{})
 
   def create_delegation(%{delegator_email: _, delegate_email: _} = args) do
-    require IEx
-    IEx.pry()
     delegator_attrs = %{email: args.delegator_email, organization_id: args.organization_id}
     delegate_attrs = %{email: args.delegate_email, organization_id: args.organization_id}
     attrs = Map.take(args, [:organization_id, :proposal_url])

--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -101,8 +101,8 @@ defmodule LiquidVoting.Delegations do
   @doc """
   Creates a delegation.
 
-  The delegation will be global if no `proposal_url` is passed in. 
-  The delegation can be created by ID or by email. 
+  The delegation will be global if no `proposal_url` is passed in.
+  The delegation can be created by ID or by email.
 
   ## Examples
 
@@ -116,6 +116,8 @@ defmodule LiquidVoting.Delegations do
   def create_delegation(attrs \\ %{})
 
   def create_delegation(%{delegator_email: _, delegate_email: _} = args) do
+    require IEx
+    IEx.pry()
     delegator_attrs = %{email: args.delegator_email, organization_id: args.organization_id}
     delegate_attrs = %{email: args.delegate_email, organization_id: args.organization_id}
     attrs = Map.take(args, [:organization_id, :proposal_url])

--- a/lib/liquid_voting/delegations/delegation.ex
+++ b/lib/liquid_voting/delegations/delegation.ex
@@ -10,6 +10,7 @@ defmodule LiquidVoting.Delegations.Delegation do
   schema "delegations" do
     field :proposal_url, EctoFields.URL
     field :organization_id, Ecto.UUID
+    field :global, :boolean
 
     belongs_to :delegator, Participant
     belongs_to :delegate, Participant

--- a/lib/liquid_voting/delegations/delegation.ex
+++ b/lib/liquid_voting/delegations/delegation.ex
@@ -21,13 +21,23 @@ defmodule LiquidVoting.Delegations.Delegation do
   @doc false
   def changeset(delegation, attrs) do
     required_fields = [:delegator_id, :delegate_id, :organization_id]
-    all_fields = [:proposal_url | required_fields]
+    all_fields = [:proposal_url, :global | required_fields]
 
     delegation
     |> cast(attrs, all_fields)
     |> assoc_constraint(:delegator)
     |> assoc_constraint(:delegate)
     |> validate_required(required_fields)
+    |> set_global()
     |> unique_constraint(:org_delegator_delegate, name: :uniq_index_org_delegator_delegate)
+  end
+
+  defp set_global(changeset) do
+    case get_field(changeset, :proposal_url) do
+      # If proposal_url is nil, delegation is global
+      nil -> put_change(changeset, :global, true)
+      # If proposal_url is not nil, delegation is not global
+      _ -> put_change(changeset, :global, false)
+    end
   end
 end

--- a/priv/repo/migrations/20200817123412_add_delegations_global_boolean.exs
+++ b/priv/repo/migrations/20200817123412_add_delegations_global_boolean.exs
@@ -1,0 +1,9 @@
+defmodule LiquidVoting.Repo.Migrations.AddDelegationsGlobalBoolean do
+  use Ecto.Migration
+
+  def change do
+    alter table(:delegations) do
+      add :global, :boolean
+    end
+  end
+end

--- a/test/liquid_voting/delegations_test.exs
+++ b/test/liquid_voting/delegations_test.exs
@@ -61,6 +61,21 @@ defmodule LiquidVoting.DelegationsTest do
       assert {:ok, %Delegation{} = delegation} = Delegations.create_delegation(args)
     end
 
+    test "create_delegation/1 with proposal url sets global boolean to false", context do
+      proposal_url = "https://www.someorg/proposalX"
+
+      args = Map.merge(context[:valid_attrs], %{proposal_url: proposal_url})
+      {:ok, %Delegation{} = delegation} = Delegations.create_delegation(args)
+
+      assert delegation.global == false
+    end
+
+    test "create_delegation/1 without proposal url sets global boolean to true", context do
+      {:ok, %Delegation{} = delegation} = Delegations.create_delegation(context[:valid_attrs])
+
+      assert delegation.global == true
+    end
+
     test "create_delegation/1 with duplicate data returns error changeset", context do
       Delegations.create_delegation(context[:valid_attrs])
       assert {:error, %Ecto.Changeset{}} = Delegations.create_delegation(context[:valid_attrs])

--- a/test/liquid_voting/delegations_test.exs
+++ b/test/liquid_voting/delegations_test.exs
@@ -51,7 +51,7 @@ defmodule LiquidVoting.DelegationsTest do
       assert {:error, %Ecto.Changeset{}} = Delegations.create_delegation(context[:invalid_attrs])
     end
 
-    test "create_delegation/1 with proposal urls creates a delegation", context do
+    test "create_delegation/1 with proposal url creates a delegation", context do
       # Test long urls while at it
       proposal_url = """
       https://www.bigassstring.com/search?ei=WdznXfzyIoeT1fAP79yWqAc&q=chrome+extension+popup+js+xhr+onload+document.body&oq=chrome+extension+popup+js+xhr+onload+document.body&gs_l=psy-ab.3...309222.313422..314027...0.0..1.201.1696.5j9j1....2..0....1..gws-wiz.2OvPoKSwZ_I&ved=0ahUKEwi8g5fQspzmAhWHSRUIHW-uBXUQ4dUDCAs&uact=5"


### PR DESCRIPTION
Closes [#110](https://github.com/liquidvotingio/api/issues/110)  

I have not exposed the `global` boolean to the absinthe layer as I was not sure if we want to do this, and it also seems beyond the scope of this issue. If we do expose this field to the absinthe layer, then we could list delegations by `global == true` or `global == false` via GraphQL queries, for example. Thoughts?