### PR TITLE
Add tests of double delegations scenarios

### DIFF
--- a/test/liquid_voting/delegations_test.exs
+++ b/test/liquid_voting/delegations_test.exs
@@ -14,6 +14,7 @@ defmodule LiquidVoting.DelegationsTest do
       proposal_url = "https://www.someorg/proposalX"
 
       [
+        proposal_url: proposal_url,
         valid_attrs: %{
           delegator_id: delegator.id,
           delegate_id: delegate.id,
@@ -69,7 +70,7 @@ defmodule LiquidVoting.DelegationsTest do
       assert {:ok, %Delegation{} = delegation} = Delegations.create_delegation(args)
     end
 
-    test "create_delegation/1 with duplicate data returns error changeset", context do
+    test "create_delegation/1 with duplicate data returns error changeset" do
       original_delegation = insert(:delegation)
 
       args = %{
@@ -83,7 +84,7 @@ defmodule LiquidVoting.DelegationsTest do
 
     test "create_delegation/1 with duplicate proposal-specific data returns error changeset",
          context do
-      original_delegation = insert(:delegation, proposal_url: "https://www.someorg/proposalX")
+      original_delegation = insert(:delegation, proposal_url: context[:proposal_url])
 
       args = %{
         delegator_id: original_delegation.delegator_id,
@@ -103,7 +104,7 @@ defmodule LiquidVoting.DelegationsTest do
         delegator_id: original_delegation.delegator_id,
         delegate_id: original_delegation.delegate_id,
         organization_id: original_delegation.organization_id,
-        proposal_url: @proposal_url
+        proposal_url: context[:proposal_url]
       }
 
       assert {:error, %Ecto.Changeset{}} = Delegations.create_delegation(args)
@@ -111,7 +112,7 @@ defmodule LiquidVoting.DelegationsTest do
 
     test "create_delegation/1 with global delegation data returns error if proposal-specific delegation for same delegator/delegate pair exists",
          context do
-      original_delegation = insert(:delegation, proposal_url: "https://www.someorg/proposalX")
+      original_delegation = insert(:delegation, proposal_url: context[:proposal_url])
 
       args = %{
         delegator_id: original_delegation.delegator_id,
@@ -135,7 +136,7 @@ defmodule LiquidVoting.DelegationsTest do
 
     test "upsert_delegation/1 with duplicate delegator and proposal_url updates the respective delegation",
          context do
-      original_delegation = insert(:delegation, proposal_url: "https://www.someorg/proposalX")
+      original_delegation = insert(:delegation, proposal_url: context[:proposal_url])
       new_delegate = insert(:participant)
 
       args = %{
@@ -151,8 +152,7 @@ defmodule LiquidVoting.DelegationsTest do
       assert original_delegation.delegator_id == modified_delegation.delegator_id
     end
 
-    test "upsert_delegation/1 for global delegation with duplicate delegator updates the respective delegation",
-         context do
+    test "upsert_delegation/1 for global delegation with duplicate delegator updates the respective delegation" do
       original_delegation = insert(:delegation)
       new_delegate = insert(:participant)
 

--- a/test/liquid_voting/delegations_test.exs
+++ b/test/liquid_voting/delegations_test.exs
@@ -74,6 +74,14 @@ defmodule LiquidVoting.DelegationsTest do
       assert {:error, %Ecto.Changeset{}} = Delegations.create_delegation(context[:valid_attrs])
     end
 
+    test "create_delegation/1 with duplicate proposal-specific data returns error changeset",
+         context do
+      Delegations.create_delegation(context[:valid_proposal_specific_attrs])
+
+      assert {:error, %Ecto.Changeset{}} =
+               Delegations.create_delegation(context[:valid_proposal_specific_attrs])
+    end
+
     test "upsert_delegation/1 with valid proposal_specific delegation data creates a delegation",
          context do
       assert {:ok, %Delegation{} = delegation} =

--- a/test/liquid_voting/delegations_test.exs
+++ b/test/liquid_voting/delegations_test.exs
@@ -94,8 +94,7 @@ defmodule LiquidVoting.DelegationsTest do
          context do
       Delegations.create_delegation(context[:valid_proposal_specific_attrs])
 
-      assert {:error, %Ecto.Changeset{}} =
-               Delegations.create_delegation(context[:valid_attrs])
+      assert {:error, %Ecto.Changeset{}} = Delegations.create_delegation(context[:valid_attrs])
     end
 
     test "upsert_delegation/1 with valid proposal_specific delegation data creates a delegation",

--- a/test/liquid_voting/delegations_test.exs
+++ b/test/liquid_voting/delegations_test.exs
@@ -82,6 +82,18 @@ defmodule LiquidVoting.DelegationsTest do
                Delegations.create_delegation(context[:valid_proposal_specific_attrs])
     end
 
+    test "create_delegation/1 with proposal-specifc data returns error if global delegation for same delegator/delegate pair exists",
+         context do
+      Delegations.create_delegation(context[:valid_attrs])
+
+      assert {:error, %Ecto.Changeset{}} =
+               Delegations.create_delegation(context[:valid_proposal_specific_attrs])
+    end
+
+    #create_delegation/1 with proposal-specifc data returns error if global delegation for same delegator/delegate pair exists
+
+    #create_delegation/1 with global delegation data returns error if proposal-specific delegation for same delegator/delegate pair exists
+
     test "upsert_delegation/1 with valid proposal_specific delegation data creates a delegation",
          context do
       assert {:ok, %Delegation{} = delegation} =

--- a/test/liquid_voting/delegations_test.exs
+++ b/test/liquid_voting/delegations_test.exs
@@ -38,8 +38,6 @@ defmodule LiquidVoting.DelegationsTest do
       ]
     end
 
-    @proposal_url "https://www.someorg/proposalX"
-
     test "list_delegations/1 returns all delegations for an organization_id" do
       delegation = insert(:delegation)
       assert Delegations.list_delegations(delegation.organization_id) == [delegation]
@@ -85,7 +83,7 @@ defmodule LiquidVoting.DelegationsTest do
 
     test "create_delegation/1 with duplicate proposal-specific data returns error changeset",
          context do
-      original_delegation = insert(:delegation, proposal_url: @proposal_url)
+      original_delegation = insert(:delegation, proposal_url: "https://www.someorg/proposalX")
 
       args = %{
         delegator_id: original_delegation.delegator_id,
@@ -113,7 +111,7 @@ defmodule LiquidVoting.DelegationsTest do
 
     test "create_delegation/1 with global delegation data returns error if proposal-specific delegation for same delegator/delegate pair exists",
          context do
-      original_delegation = insert(:delegation, proposal_url: @proposal_url)
+      original_delegation = insert(:delegation, proposal_url: "https://www.someorg/proposalX")
 
       args = %{
         delegator_id: original_delegation.delegator_id,
@@ -137,7 +135,7 @@ defmodule LiquidVoting.DelegationsTest do
 
     test "upsert_delegation/1 with duplicate delegator and proposal_url updates the respective delegation",
          context do
-      original_delegation = insert(:delegation, proposal_url: @proposal_url)
+      original_delegation = insert(:delegation, proposal_url: "https://www.someorg/proposalX")
       new_delegate = insert(:participant)
 
       args = %{

--- a/test/liquid_voting/delegations_test.exs
+++ b/test/liquid_voting/delegations_test.exs
@@ -90,9 +90,13 @@ defmodule LiquidVoting.DelegationsTest do
                Delegations.create_delegation(context[:valid_proposal_specific_attrs])
     end
 
-    #create_delegation/1 with proposal-specifc data returns error if global delegation for same delegator/delegate pair exists
+    test "create_delegation/1 with global delegation data returns error if proposal-specific delegation for same delegator/delegate pair exists",
+         context do
+      Delegations.create_delegation(context[:valid_proposal_specific_attrs])
 
-    #create_delegation/1 with global delegation data returns error if proposal-specific delegation for same delegator/delegate pair exists
+      assert {:error, %Ecto.Changeset{}} =
+               Delegations.create_delegation(context[:valid_attrs])
+    end
 
     test "upsert_delegation/1 with valid proposal_specific delegation data creates a delegation",
          context do


### PR DESCRIPTION
closes [#115](https://github.com/liquidvotingio/api/issues/115)

I added 3 tests:

1. `create_delegation/1 with duplicate proposal-specific data returns error changeset`  
2. `create_delegation/1 with proposal-specifc data returns error if global delegation for same delegator/delegate pair exists`
3. `create_delegation/1 with global delegation data returns error if proposal-specific delegation for same delegator/delegate pair exists`