### PR TITLE
Validate delegator and delegate are different

### DIFF
--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -181,8 +181,6 @@ defmodule LiquidVoting.Delegations do
     end
     |> Delegation.changeset(attrs)
     |> Repo.insert_or_update()
-
-    # |> IO.inspect
   end
 
   defp where_proposal(query, _proposal_url = nil),

--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -181,6 +181,8 @@ defmodule LiquidVoting.Delegations do
     end
     |> Delegation.changeset(attrs)
     |> Repo.insert_or_update()
+
+    # |> IO.inspect
   end
 
   defp where_proposal(query, _proposal_url = nil),

--- a/lib/liquid_voting/delegations/delegation.ex
+++ b/lib/liquid_voting/delegations/delegation.ex
@@ -27,6 +27,17 @@ defmodule LiquidVoting.Delegations.Delegation do
     |> assoc_constraint(:delegator)
     |> assoc_constraint(:delegate)
     |> validate_required(required_fields)
+    |> validate_participants_different
     |> unique_constraint(:org_delegator_delegate, name: :uniq_index_org_delegator_delegate)
+  end
+
+  defp validate_participants_different(changeset) do
+    delegator_id = get_field(changeset, :delegator_id)
+    delegate_id = get_field(changeset, :delegate_id)
+
+    case delegator_id == delegate_id do
+      true -> add_error(changeset, :delegate_id, "delegator and delegate must be different")
+      false -> changeset
+    end
   end
 end

--- a/lib/liquid_voting/delegations/delegation.ex
+++ b/lib/liquid_voting/delegations/delegation.ex
@@ -35,7 +35,8 @@ defmodule LiquidVoting.Delegations.Delegation do
     delegator_id = get_field(changeset, :delegator_id)
     delegate_id = get_field(changeset, :delegate_id)
 
-    case delegator_id == delegate_id do
+    # we are only checking if non-nil ids match, as validate_required/1 will catch nil case(s)
+    case delegator_id == delegate_id && delegator_id != nil do
       true -> add_error(changeset, :delegate_id, "delegator and delegate must be different")
       false -> changeset
     end

--- a/lib/liquid_voting/delegations/delegation.ex
+++ b/lib/liquid_voting/delegations/delegation.ex
@@ -35,7 +35,7 @@ defmodule LiquidVoting.Delegations.Delegation do
     delegator_id = get_field(changeset, :delegator_id)
     delegate_id = get_field(changeset, :delegate_id)
 
-    # we are only checking if non-nil ids match, as validate_required/1 will catch nil case(s)
+    # we are only checking if non-nil ids match, as validate_required/1 will catch nil case
     case delegator_id == delegate_id && delegator_id != nil do
       true -> add_error(changeset, :delegate_id, "delegator and delegate must be different")
       false -> changeset

--- a/test/liquid_voting/delegations_test.exs
+++ b/test/liquid_voting/delegations_test.exs
@@ -60,6 +60,19 @@ defmodule LiquidVoting.DelegationsTest do
       assert {:error, %Ecto.Changeset{}} = Delegations.create_delegation(context[:invalid_attrs])
     end
 
+    test "create_delegation/1 with same participant as delegator and delegate returns error changeset",
+         context do
+      participant = insert(:participant)
+
+      args = %{
+        delegator_id: participant.id,
+        delegate_id: participant.id,
+        organization_id: Ecto.UUID.generate()
+      }
+
+      assert {:error, %Ecto.Changeset{}} = Delegations.create_delegation(args)
+    end
+
     test "create_delegation/1 with proposal url creates a delegation", context do
       # Test long urls while at it
       proposal_url = """

--- a/test/liquid_voting_web/absinthe/mutations/create_delegation_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/create_delegation_test.exs
@@ -191,11 +191,34 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegationTest do
       assert details == %{delegate_id: ["can't be blank"]}
     end
 
-    test "with identical emails for delegator and delegate" do
+    test "with identical emails for delegator and delegate", context do
       query = """
       mutation {
-        createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{
-        @delegator_email
+        createDelegation(delegatorEmail: "#{context[:delegator].email}", delegateEmail: "#{
+        context[:delegator].email
+      }") {
+          delegator {
+            email
+          }
+          delegate {
+            email
+          }
+        }
+      }
+      """
+
+      {:ok, %{errors: [%{message: message, details: details}]}} =
+        Absinthe.run(query, Schema, context: %{organization_id: Ecto.UUID.generate()})
+
+      assert message == "Could not create delegation"
+      assert details == %{delegate_id: ["delegator and delegate must be different"]}
+    end
+
+    test "with identical ids for delegator and delegate", context do
+      query = """
+      mutation {
+        createDelegation(delegatorId: "#{context[:delegator].id}", delegateId: "#{
+        context[:delegator].id
       }") {
           delegator {
             email

--- a/test/liquid_voting_web/absinthe/mutations/create_delegation_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/create_delegation_test.exs
@@ -190,6 +190,29 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegationTest do
       assert message == "Could not create delegation"
       assert details == %{delegate_id: ["can't be blank"]}
     end
+
+    test "with identical emails for delegator and delegate" do
+      query = """
+      mutation {
+        createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{
+        @delegator_email
+      }") {
+          delegator {
+            email
+          }
+          delegate {
+            email
+          }
+        }
+      }
+      """
+
+      {:ok, %{errors: [%{message: message, details: details}]}} =
+        Absinthe.run(query, Schema, context: %{organization_id: Ecto.UUID.generate()})
+
+      assert message == "Could not create delegation"
+      assert details == %{delegate_id: ["delegator and delegate must be different"]}
+    end
   end
 
   describe "create new global delegation for delegator with existing global delegation" do


### PR DESCRIPTION
closes [#45](https://github.com/liquidvotingio/api/issues/45)  

Q: Do we want the changeset error to apply to both fields (`delegator_id` & `delegate_id`)? I have only applied it to `delegate_id` (arbitrary choice).  
Q: Do we want a different error wording? I have suggested `delegate_id: ["delegator and delegate must be different"]`