### PR TITLE
Correct error for missing delegate field

### DIFF
--- a/lib/liquid_voting_web/resolvers/delegations.ex
+++ b/lib/liquid_voting_web/resolvers/delegations.ex
@@ -13,7 +13,7 @@ defmodule LiquidVotingWeb.Resolvers.Delegations do
   # with create_delegation_with_valid_arguments/1
   def create_delegation(_, args, %{context: %{organization_id: organization_id}}) do
     args
-    |> validate_participant_fields_provided
+    |> validate_participant_args
     |> case do
       {:ok, args} ->
         args
@@ -39,7 +39,7 @@ defmodule LiquidVotingWeb.Resolvers.Delegations do
     end
   end
 
-  defp validate_participant_fields_provided(args) do
+  defp validate_participant_args(args) do
     args
     |> case do
       %{delegator_email: _, delegate_email: _} ->

--- a/lib/liquid_voting_web/resolvers/delegations.ex
+++ b/lib/liquid_voting_web/resolvers/delegations.ex
@@ -48,41 +48,34 @@ defmodule LiquidVotingWeb.Resolvers.Delegations do
       %{delegator_id: _, delegate_id: _} ->
         {:ok, args}
 
-      # if delegator_email field exists, but no delegate_email field exists
+      # delegator_email field provided, but no delegate_email field provided
       %{delegator_email: _} ->
-        {:error,
-         %{
-           message: "Could not create delegation",
-           details: %{delegate_email: ["field not found"]}
-         }}
+        field_not_found_error(%{delegate_email: ["field not found"]})
 
-      # if delegate_email field exists, but no delegator_email field exists
+      # delegate_email field provided, but no delegator_email field provided
       %{delegate_email: _} ->
-        {:error,
-         %{
-           message: "Could not create delegation",
-           details: %{delegator_email: ["field not found"]}
-         }}
+        field_not_found_error(%{delegator_email: ["field not found"]})
 
-      # if delegator_id field exists, but no delegate_id field exists
+      # delegator_id field provided, but no delegate_id field provided
       %{delegator_id: _} ->
-        {:error,
-         %{
-           message: "Could not create delegation",
-           details: %{delegate_id: ["field not found"]}
-         }}
+        field_not_found_error(%{delegate_id: ["field not found"]})
 
-      # if delegate_id field exists, but no delegator_id field exists
+      # delegate_id field provided, but no delegator_id field provided
       %{delegate_id: _} ->
-        {:error,
-         %{
-           message: "Could not create delegation",
-           details: %{delegator_id: ["field not found"]}
-         }}
-
+        field_not_found_error(%{delegator_id: ["field not found"]})
+       
+      # no id or email fields for delegator and delegate provided
       _ ->
-        {:error, "some generic error - as yet undecided"}
+        field_not_found_error("emails or ids identifying delegator and delegate not found")
     end
+  end
+
+  defp field_not_found_error(details) do
+    {:error,
+     %{
+       message: "Could not create delegation",
+       details: details
+     }}
   end
 
   # Delete proposal-specific delegations

--- a/lib/liquid_voting_web/resolvers/delegations.ex
+++ b/lib/liquid_voting_web/resolvers/delegations.ex
@@ -73,8 +73,7 @@ defmodule LiquidVotingWeb.Resolvers.Delegations do
   end
 
   defp validate_participant_args(args) do
-    args
-    |> case do
+    case args do
       %{delegator_email: _, delegate_email: _} ->
         {:ok, args}
 

--- a/lib/liquid_voting_web/resolvers/delegations.ex
+++ b/lib/liquid_voting_web/resolvers/delegations.ex
@@ -8,20 +8,42 @@ defmodule LiquidVotingWeb.Resolvers.Delegations do
   def delegation(_, %{id: id}, %{context: %{organization_id: organization_id}}),
     do: {:ok, Delegations.get_delegation!(id, organization_id)}
 
-  # Creates a delegation.
+  @doc """
+  Creates a delegation.
 
-  # Adds participants to the db if they don't exist yet, or fetch them if they do.
+  Adds participants to the db if they don't exist, or fetches them if they do.
 
-  # Valid arguments (args) must include 2 ids (delegator_id and delegate_id)
-  # OR 2 emails (delegator_email and delegate_email).
+  Valid arguments (args) must include 2 ids (delegator_id and delegate_id)
+  OR 2 emails (delegator_email and delegate_email).
 
-  # Valid arguments (args) may include a proposal_url.
-  # Without a proposal_url, an attempt to create a global delegation will occur.
+  Valid arguments (args) may include a proposal_url.
+  Without a proposal_url, an attempt to create a global delegation will occur.
 
-  # The participant ids, either directly taken from delegator_id and
-  # delegate_id, or via searching the db for pariticpants with the emails
-  # provided, are used when inserting the delegation with
-  # LiquidVoting.Delegations.create_delegation/1.
+  The participant ids, either directly taken from delegator_id and
+  delegate_id, or via searching the db for participants with the emails
+  provided, are used when inserting the delegation with
+  LiquidVoting.Delegations.create_delegation/1.
+
+  ## Examples
+
+  iex> create_delegation(
+    %{},
+    %{delegator_email: "alice@somemail.com",
+    delegate_email: "bob@somemail.com",
+    proposal_url: "https://proposalplace/proposal63"},
+    %{context: %{organization_id: "b212ef83-d3df-4a7a-8875-36cca613e8d6"}})
+  %Delegation{}
+
+  iex> create_delegation(
+    %{},
+    %{delegator_email: "alice@somemail.com"},
+    %{context: %{organization_id: "b212ef83-d3df-4a7a-8875-36cca613e8d6"}})
+  {:error,                                                   
+    %{
+      details: %{delegate_email: ["can't be blank"]},
+      message: "Could not create delegation"
+    }}
+  """
   def create_delegation(_, args, %{context: %{organization_id: organization_id}}) do
     args
     |> validate_participant_args

--- a/lib/liquid_voting_web/resolvers/delegations.ex
+++ b/lib/liquid_voting_web/resolvers/delegations.ex
@@ -50,23 +50,23 @@ defmodule LiquidVotingWeb.Resolvers.Delegations do
 
       # delegator_email field provided, but no delegate_email field provided
       %{delegator_email: _} ->
-        field_not_found_error(%{delegate_email: ["field not found"]})
+        field_not_found_error(%{delegate_email: ["can't be blank"]})
 
       # delegate_email field provided, but no delegator_email field provided
       %{delegate_email: _} ->
-        field_not_found_error(%{delegator_email: ["field not found"]})
+        field_not_found_error(%{delegator_email: ["can't be blank"]})
 
       # delegator_id field provided, but no delegate_id field provided
       %{delegator_id: _} ->
-        field_not_found_error(%{delegate_id: ["field not found"]})
+        field_not_found_error(%{delegate_id: ["can't be blank"]})
 
       # delegate_id field provided, but no delegator_id field provided
       %{delegate_id: _} ->
-        field_not_found_error(%{delegator_id: ["field not found"]})
+        field_not_found_error(%{delegator_id: ["can't be blank"]})
        
       # no id or email fields for delegator and delegate provided
       _ ->
-        field_not_found_error("emails or ids identifying delegator and delegate not found")
+        field_not_found_error("emails or ids identifying delegator and delegate can't be blank")
     end
   end
 

--- a/lib/liquid_voting_web/resolvers/delegations.ex
+++ b/lib/liquid_voting_web/resolvers/delegations.ex
@@ -13,7 +13,7 @@ defmodule LiquidVotingWeb.Resolvers.Delegations do
   # with create_delegation_with_valid_arguments/1
   def create_delegation(_, args, %{context: %{organization_id: organization_id}}) do
     args
-    |> validate_participants
+    |> validate_participant_fields_provided
     |> case do
       {:ok, args} ->
         args
@@ -39,44 +39,49 @@ defmodule LiquidVotingWeb.Resolvers.Delegations do
     end
   end
 
-  defp validate_participants(args) do
+  defp validate_participant_fields_provided(args) do
     args
     |> case do
       %{delegator_email: _, delegate_email: _} ->
         {:ok, args}
-      
+
       %{delegator_id: _, delegate_id: _} ->
         {:ok, args}
 
       # if delegator_email field exists, but no delegate_email field exists
       %{delegator_email: _} ->
-        {:error, %{
-          message: "Could not create delegation",
-          details: %{delegate_email: ["field not found"]}
-        }}
+        {:error,
+         %{
+           message: "Could not create delegation",
+           details: %{delegate_email: ["field not found"]}
+         }}
 
       # if delegate_email field exists, but no delegator_email field exists
       %{delegate_email: _} ->
-        {:error, %{
-          message: "Could not create delegation",
-          details: %{delegator_email: ["field not found"]}
-        }}
+        {:error,
+         %{
+           message: "Could not create delegation",
+           details: %{delegator_email: ["field not found"]}
+         }}
 
       # if delegator_id field exists, but no delegate_id field exists
       %{delegator_id: _} ->
-        {:error, %{
-          message: "Could not create delegation",
-          details: %{delegate_id: ["field not found"]}
-        }}
+        {:error,
+         %{
+           message: "Could not create delegation",
+           details: %{delegate_id: ["field not found"]}
+         }}
 
       # if delegate_id field exists, but no delegator_id field exists
       %{delegate_id: _} ->
-        {:error, %{
-          message: "Could not create delegation",
-          details: %{delegator_id: ["field not found"]}
-        }}
+        {:error,
+         %{
+           message: "Could not create delegation",
+           details: %{delegator_id: ["field not found"]}
+         }}
 
-      _ -> {:error, "some generic error - as yet undecided"}
+      _ ->
+        {:error, "some generic error - as yet undecided"}
     end
   end
 

--- a/lib/liquid_voting_web/resolvers/delegations.ex
+++ b/lib/liquid_voting_web/resolvers/delegations.ex
@@ -63,8 +63,8 @@ defmodule LiquidVotingWeb.Resolvers.Delegations do
       # delegate_id field provided, but no delegator_id field provided
       %{delegate_id: _} ->
         field_not_found_error(%{delegator_id: ["can't be blank"]})
-       
-      # no id or email fields for delegator and delegate provided
+
+      # no id or email fields provided for delegator and delegate
       _ ->
         field_not_found_error("emails or ids identifying delegator and delegate can't be blank")
     end

--- a/lib/liquid_voting_web/resolvers/delegations.ex
+++ b/lib/liquid_voting_web/resolvers/delegations.ex
@@ -8,9 +8,20 @@ defmodule LiquidVotingWeb.Resolvers.Delegations do
   def delegation(_, %{id: id}, %{context: %{organization_id: organization_id}}),
     do: {:ok, Delegations.get_delegation!(id, organization_id)}
 
-  # Will add participants to the db if they don't exist yet, or fetch them if they do. 
-  # Their ids are used for delegator_id and delegate_id when inserting the delegation
-  # with create_delegation_with_valid_arguments/1
+  # Creates a delegation.
+
+  # Adds participants to the db if they don't exist yet, or fetch them if they do.
+
+  # Valid arguments (args) must include 2 ids (delegator_id and delegate_id)
+  # OR 2 emails (delegator_email and delegate_email).
+
+  # Valid arguments (args) may include a proposal_url.
+  # Without a proposal_url, an attempt to create a global delegation will occur.
+
+  # The participant ids, either directly taken from delegator_id and
+  # delegate_id, or via searching the db for pariticpants with the emails
+  # provided, are used when inserting the delegation with
+  # LiquidVoting.Delegations.create_delegation/1.
   def create_delegation(_, args, %{context: %{organization_id: organization_id}}) do
     args
     |> validate_participant_args

--- a/lib/liquid_voting_web/resolvers/delegations.ex
+++ b/lib/liquid_voting_web/resolvers/delegations.ex
@@ -12,6 +12,15 @@ defmodule LiquidVotingWeb.Resolvers.Delegations do
   # Their ids are used for delegator_id and delegate_id when inserting the delegation
   # with create_delegation_with_valid_arguments/1
   def create_delegation(_, args, %{context: %{organization_id: organization_id}}) do
+    args =
+    cond do
+      Map.has_key?(args, :delegator_email) && Map.has_key?(args, :delegate_email) == false
+        -> Map.put(args, :delegate_email, nil)
+      Map.has_key?(args, :delegate_email) && Map.has_key?(args, :delegator_email) == false
+        -> Map.put(args, :delegator_email, nil)
+      true -> args
+    end
+    
     args
     |> Map.put(:organization_id, organization_id)
     |> Delegations.create_delegation()

--- a/lib/liquid_voting_web/resolvers/delegations.ex
+++ b/lib/liquid_voting_web/resolvers/delegations.ex
@@ -47,18 +47,18 @@ defmodule LiquidVotingWeb.Resolvers.Delegations do
   def create_delegation(_, args, %{context: %{organization_id: organization_id}}) do
     args = Map.put(args, :organization_id, organization_id)
 
-    with {:step1, {:ok, args}} <- {:step1, validate_participant_args(args)},
-         {:step2, {:ok, delegation}} <- {:step2, Delegations.create_delegation(args)} do
+    with {:ok, args} <- validate_participant_args(args),
+         {:ok, delegation} <- Delegations.create_delegation(args) do
       {:ok, delegation}
     else
-      {:step1, {:error, message}} ->
-        {:error, message}
+      {:error, %{message: message, details: details}} ->
+        {:error, %{message: message, details: details}}
 
-      {:step2, {:error, changeset}} ->
+      {:error, changeset} ->
         {:error,
          message: "Could not create delegation", details: ChangesetErrors.error_details(changeset)}
 
-      {:step2, {:error, name, changeset, _}} ->
+      {:error, name, changeset, _} ->
         {:error,
          message: "Could not create #{name}", details: ChangesetErrors.error_details(changeset)}
     end

--- a/test/liquid_voting/delegations_test.exs
+++ b/test/liquid_voting/delegations_test.exs
@@ -60,8 +60,7 @@ defmodule LiquidVoting.DelegationsTest do
       assert {:error, %Ecto.Changeset{}} = Delegations.create_delegation(context[:invalid_attrs])
     end
 
-    test "create_delegation/1 with same participant as delegator and delegate returns error changeset",
-         context do
+    test "create_delegation/1 with same participant as delegator and delegate returns error changeset" do
       participant = insert(:participant)
 
       args = %{

--- a/test/liquid_voting_web/absinthe/mutations/create_delegation_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/create_delegation_test.exs
@@ -109,7 +109,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegationTest do
         Absinthe.run(query, Schema, context: %{organization_id: Ecto.UUID.generate()})
 
       assert message == "Could not create delegation"
-      assert details == %{delegate_email: ["field not found"]}
+      assert details == %{delegate_email: ["can't be blank"]}
     end
   end
 
@@ -188,7 +188,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegationTest do
         Absinthe.run(query, Schema, context: %{organization_id: Ecto.UUID.generate()})
 
       assert message == "Could not create delegation"
-      assert details == %{delegate_id: ["field not found"]}
+      assert details == %{delegate_id: ["can't be blank"]}
     end
 
     test "with identical emails for delegator and delegate", context do

--- a/test/liquid_voting_web/absinthe/mutations/create_delegation_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/create_delegation_test.exs
@@ -89,7 +89,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegationTest do
       assert delegation["votingResult"]["against"] == 0
     end
 
-    test "with missing fields" do
+    test "with missing delegate email field" do
       query = """
       mutation {
         createDelegation(delegatorEmail: "#{@delegator_email}") {
@@ -170,7 +170,28 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegationTest do
       assert delegation["delegate"]["email"] == context[:delegate].email
     end
 
-    test "with missing field", context do
+    test "with proposal url, but missing delegate and delegator id fields", context do
+      query = """
+      mutation {
+        createDelegation(proposalUrl: "#{@proposal_url}") {
+          delegator {
+            email
+          }
+          delegate {
+            email
+          }
+        }
+      }
+      """
+
+      {:ok, %{errors: [%{message: message, details: details}]}} =
+        Absinthe.run(query, Schema, context: %{organization_id: Ecto.UUID.generate()})
+
+      assert message == "Could not create delegation"
+      assert details == "emails or ids identifying delegator and delegate can't be blank"
+    end
+
+    test "with missing delegate id field", context do
       query = """
       mutation {
         createDelegation(delegatorId: "#{context[:delegator].id}") {

--- a/test/liquid_voting_web/absinthe/mutations/create_delegation_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/create_delegation_test.exs
@@ -170,7 +170,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegationTest do
       assert delegation["delegate"]["email"] == context[:delegate].email
     end
 
-    test "with proposal url, but missing delegate and delegator id fields", context do
+    test "with proposal url, but missing delegate and delegator id fields" do
       query = """
       mutation {
         createDelegation(proposalUrl: "#{@proposal_url}") {

--- a/test/liquid_voting_web/absinthe/mutations/create_delegation_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/create_delegation_test.exs
@@ -108,8 +108,8 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegationTest do
       {:ok, %{errors: [%{message: message, details: details}]}} =
         Absinthe.run(query, Schema, context: %{organization_id: Ecto.UUID.generate()})
 
-      assert message == "Could not create delegate"
-      assert details == %{email: ["can't be blank"]}
+      assert message == "Could not create delegation"
+      assert details == %{delegate_email: ["field not found"]}
     end
   end
 
@@ -188,7 +188,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegationTest do
         Absinthe.run(query, Schema, context: %{organization_id: Ecto.UUID.generate()})
 
       assert message == "Could not create delegation"
-      assert details == %{delegate_id: ["can't be blank"]}
+      assert details == %{delegate_id: ["field not found"]}
     end
 
     test "with identical emails for delegator and delegate", context do

--- a/test/liquid_voting_web/absinthe/mutations/create_delegation_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/create_delegation_test.exs
@@ -108,8 +108,8 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegationTest do
       {:ok, %{errors: [%{message: message, details: details}]}} =
         Absinthe.run(query, Schema, context: %{organization_id: Ecto.UUID.generate()})
 
-      assert message == "Could not create delegation"
-      assert details == %{delegate_id: ["can't be blank"], delegator_id: ["can't be blank"]}
+      assert message == "Could not create delegate"
+      assert details == %{email: ["can't be blank"]}
     end
   end
 


### PR DESCRIPTION
closes #118  

**TLDR**: This 'fixes' the problem, but I don't particularly like the fix, and it perhaps raises more questions than it answers. This PR aims to stimulate discussion on the topic.  

**The issue:**  
createDelegation mutation with only 1 email field provided, misleadingly leads to an error of: `Could not create delegation ... %{delegate_id: ["can't be blank"], delegator_id: ["can't be blank"]}` This error does not help the user identify the missing email field.  

**The workaround:**     
Detect such a missing field (and the presence of one email field), and add the complimentary email field with a value of nil. Now a missing `:delegator_email` returns an error of `Could not create delegate ... email: ["can't be blank"]`, which is more useful.  

**Observations:**  
I have placed the 'fix' in the beginning of the `lib/liquid_voting_web/resolvers/delegations.ex create_delegation/3` function. It could go elsewhere (pattern matching in `lib/liquid_voting/delegations.ex create_delegation/1`, for example).  

**Questions raised:**  
This seems to be a product of having 2 different ways to identify participants at the absinthe layer (ids & emails). Should we be handling all possible cases? E.g. 1 id & 1 email, 2 ids, 2 emails, only 1 id, only 1 email, or nothing. We might well now be handling all these cases appropriately, but I would have to test more thoroughly to check, and I wanted to know if this issue signals a need for a more fundamental shift in approach, or just a different approach, before I start down that road.   
Also, does none of this matter, since the user UI will 'decide' how to fill in fields and these edge cases will never arise (is this YAGNI)?

Thoughts?