### PR TITLE
Avoid incorrect delegation deletion

### DIFF
--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -90,7 +90,6 @@ defmodule LiquidVoting.Delegations do
     delegator = Voting.get_participant_by_email!(delegator_email, organization_id)
     delegate = Voting.get_participant_by_email!(delegate_email, organization_id)
 
-    delegation =
       Delegation
       |> where(
         [d],

--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -90,13 +90,6 @@ defmodule LiquidVoting.Delegations do
     delegator = Voting.get_participant_by_email!(delegator_email, organization_id)
     delegate = Voting.get_participant_by_email!(delegate_email, organization_id)
 
-    # Repo.get_by!(
-    #   Delegation,
-    #   delegator_id: delegator.id,
-    #   delegate_id: delegate.id,
-    #   organization_id: organization_id
-    # )
-
     delegation =
       Delegation
       |> where(

--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -90,15 +90,15 @@ defmodule LiquidVoting.Delegations do
     delegator = Voting.get_participant_by_email!(delegator_email, organization_id)
     delegate = Voting.get_participant_by_email!(delegate_email, organization_id)
 
-      Delegation
-      |> where(
-        [d],
-        d.delegator_id == ^delegator.id and
-          d.delegate_id == ^delegate.id and
-          d.organization_id == ^organization_id and
-          is_nil(d.proposal_url)
-      )
-      |> Repo.one!()
+    Delegation
+    |> where(
+      [d],
+      d.delegator_id == ^delegator.id and
+        d.delegate_id == ^delegate.id and
+        d.organization_id == ^organization_id and
+        is_nil(d.proposal_url)
+    )
+    |> Repo.one!()
   end
 
   @doc """

--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -90,12 +90,23 @@ defmodule LiquidVoting.Delegations do
     delegator = Voting.get_participant_by_email!(delegator_email, organization_id)
     delegate = Voting.get_participant_by_email!(delegate_email, organization_id)
 
-    Repo.get_by!(
-      Delegation,
-      delegator_id: delegator.id,
-      delegate_id: delegate.id,
-      organization_id: organization_id
-    )
+    # Repo.get_by!(
+    #   Delegation,
+    #   delegator_id: delegator.id,
+    #   delegate_id: delegate.id,
+    #   organization_id: organization_id
+    # )
+
+    delegation =
+      Delegation
+      |> where(
+        [d],
+        d.delegator_id == ^delegator.id and
+          d.delegate_id == ^delegate.id and
+          d.organization_id == ^organization_id and
+          is_nil(d.proposal_url)
+      )
+      |> Repo.one!()
   end
 
   @doc """

--- a/test/liquid_voting/delegations_test.exs
+++ b/test/liquid_voting/delegations_test.exs
@@ -57,25 +57,27 @@ defmodule LiquidVoting.DelegationsTest do
     test "get_delegation!/3 returns a global delegation with given emails and organization_id" do
       delegation = insert(:delegation)
 
-      result = Delegations.get_delegation!(
-               delegation.delegator.email,
-               delegation.delegate.email,
-               delegation.organization_id
-             )
-             
+      result =
+        Delegations.get_delegation!(
+          delegation.delegator.email,
+          delegation.delegate.email,
+          delegation.organization_id
+        )
+
       assert result.id == delegation.id
     end
 
     test "get_delegation!/3 returns a proposal-specific delegation with given emails and organization_id" do
       delegation = insert(:delegation_for_proposal)
 
-      result = Delegations.get_delegation!(
-               delegation.delegator.email,
-               delegation.delegate.email,
-               delegation.proposal_url,
-               delegation.organization_id
-             )
-             
+      result =
+        Delegations.get_delegation!(
+          delegation.delegator.email,
+          delegation.delegate.email,
+          delegation.proposal_url,
+          delegation.organization_id
+        )
+
       assert result.id == delegation.id
     end
 
@@ -272,16 +274,6 @@ defmodule LiquidVoting.DelegationsTest do
         Delegations.get_delegation!(delegation.id, delegation.organization_id)
       end
     end
-
-    # test "delete_delegation/1 without proposal_url does not delete a proposal-specific delegation" do
-    # actually, I think this may only be a problem at absinthe layer, since at this level the actual
-    # delegation is required. Thus, I think the problem arises when we find a delegation to delete
-    # based on the params passed into absinthe layer.
-
-    # create a proposal specific delegation
-    # attempt to delete delegation without proposal_url field
-    # assert proposal-specific delegation still exists
-    # end
 
     test "change_delegation/1 returns a delegation changeset" do
       delegation = insert(:delegation)

--- a/test/liquid_voting/delegations_test.exs
+++ b/test/liquid_voting/delegations_test.exs
@@ -224,6 +224,16 @@ defmodule LiquidVoting.DelegationsTest do
       end
     end
 
+    # test "delete_delegation/1 without proposal_url does not delete a proposal-specific delegation" do
+      # actually, I think this may only be a problem at absinthe layer, since at this level the actual
+      # delegation is required. Thus, I think the problem arises when we find a delegation to delete
+      # based on the params passed into absinthe layer.
+
+      # create a proposal specific delegation
+      # attempt to delete delegation without proposal_url field
+      # assert proposal-specific delegation still exists
+    # end
+
     test "change_delegation/1 returns a delegation changeset" do
       delegation = insert(:delegation)
       assert %Ecto.Changeset{} = Delegations.change_delegation(delegation)

--- a/test/liquid_voting/delegations_test.exs
+++ b/test/liquid_voting/delegations_test.exs
@@ -225,13 +225,13 @@ defmodule LiquidVoting.DelegationsTest do
     end
 
     # test "delete_delegation/1 without proposal_url does not delete a proposal-specific delegation" do
-      # actually, I think this may only be a problem at absinthe layer, since at this level the actual
-      # delegation is required. Thus, I think the problem arises when we find a delegation to delete
-      # based on the params passed into absinthe layer.
+    # actually, I think this may only be a problem at absinthe layer, since at this level the actual
+    # delegation is required. Thus, I think the problem arises when we find a delegation to delete
+    # based on the params passed into absinthe layer.
 
-      # create a proposal specific delegation
-      # attempt to delete delegation without proposal_url field
-      # assert proposal-specific delegation still exists
+    # create a proposal specific delegation
+    # attempt to delete delegation without proposal_url field
+    # assert proposal-specific delegation still exists
     # end
 
     test "change_delegation/1 returns a delegation changeset" do

--- a/test/liquid_voting/delegations_test.exs
+++ b/test/liquid_voting/delegations_test.exs
@@ -43,6 +43,7 @@ defmodule LiquidVoting.DelegationsTest do
 
     test "list_delegations/1 returns all delegations for an organization_id" do
       delegation = insert(:delegation)
+
       assert Delegations.list_delegations(delegation.organization_id) == [delegation]
     end
 
@@ -51,6 +52,54 @@ defmodule LiquidVoting.DelegationsTest do
 
       assert Delegations.get_delegation!(delegation.id, delegation.organization_id) ==
                delegation
+    end
+
+    test "get_delegation!/3 returns a global delegation with given emails and organization_id" do
+      delegation = insert(:delegation)
+
+      result = Delegations.get_delegation!(
+               delegation.delegator.email,
+               delegation.delegate.email,
+               delegation.organization_id
+             )
+             
+      assert result.id == delegation.id
+    end
+
+    test "get_delegation!/3 returns a proposal-specific delegation with given emails and organization_id" do
+      delegation = insert(:delegation_for_proposal)
+
+      result = Delegations.get_delegation!(
+               delegation.delegator.email,
+               delegation.delegate.email,
+               delegation.proposal_url,
+               delegation.organization_id
+             )
+             
+      assert result.id == delegation.id
+    end
+
+    test "get_delegation!/3 returns returns error if a global delegation does not exist",
+         context do
+      assert_raise Ecto.NoResultsError, fn ->
+        Delegations.get_delegation!(
+          "random@person.com",
+          "random2@person.com",
+          context[:valid_attrs][:organization_id]
+        )
+      end
+    end
+
+    test "get_delegation!/3 returns returns error if a proposal-specific delegation does not exist",
+         context do
+      assert_raise Ecto.NoResultsError, fn ->
+        Delegations.get_delegation!(
+          "random@person.com",
+          "random2@person.com",
+          "https://proposals.com/random_proposal",
+          context[:valid_attrs][:organization_id]
+        )
+      end
     end
 
     test "create_delegation/1 with valid data creates a delegation", context do

--- a/test/liquid_voting/delegations_test.exs
+++ b/test/liquid_voting/delegations_test.exs
@@ -67,7 +67,7 @@ defmodule LiquidVoting.DelegationsTest do
       assert result.id == delegation.id
     end
 
-    test "get_delegation!/3 returns a proposal-specific delegation with given emails and organization_id" do
+    test "get_delegation!/3 returns a proposal-specific delegation with given emails, proposal_url and organization_id" do
       delegation = insert(:delegation_for_proposal)
 
       result =

--- a/test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs
@@ -103,7 +103,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.DeleteDelegationTest do
       # test case where a proposal-specific delegation already exists and we wish to delete
       # a global delegation (if one exists) for the same delegator & delegate.
 
-      # first, create a global delegation
+      # first, create a proposal-specific delegation
       # (should be some way to do this without using actual absinthe mutation)
       query = """
       mutation {

--- a/test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs
@@ -107,11 +107,13 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.DeleteDelegationTest do
       # (should be some way to do this without using actual absinthe mutation)
       query = """
       mutation {
-        createDelegation(delegatorEmail: "#{context[:delegator_email]}", delegateEmail: "#{context[:delegate_email]}", proposalUrl: "https://propsals.com/p1") {
+        createDelegation(delegatorEmail: "#{context[:delegator_email]}", delegateEmail: "#{context[:delegate_email]}", proposalUrl: "https://proposals.com/p1") {
           id
         }
       }
       """
+
+      {:ok, %{}}
 
       # now delete delegation, using same details as above, except without proposalUrl field:
       query = """
@@ -127,7 +129,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.DeleteDelegationTest do
       {:ok, %{data: %{"deleteDelegation" => delegation}}} =
         Absinthe.run(query, Schema, context: %{organization_id: context[:organization_id]})
 
-      assert delegation["proposalUrl"] == "https://propsals.com/p1"
+      assert delegation["proposalUrl"] != "https://proposals.com/p1"
 
     end
 

--- a/test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs
@@ -99,6 +99,38 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.DeleteDelegationTest do
       assert delegation["proposalUrl"] == context[:proposal_url]
     end
 
+    test "when a similar proposal-specific delegation exists", context do
+      # test case where a proposal-specific delegation already exists and we wish to delete
+      # a global delegation (if one exists) for the same delegator & delegate.
+
+      # first, create a global delegation
+      # (should be some way to do this without using actual absinthe mutation)
+      query = """
+      mutation {
+        createDelegation(delegatorEmail: "#{context[:delegator_email]}", delegateEmail: "#{context[:delegate_email]}", proposalUrl: "https://propsals.com/p1") {
+          id
+        }
+      }
+      """
+
+      # now delete delegation, using same details as above, except without proposalUrl field:
+      query = """
+      mutation {
+        deleteDelegation(delegatorEmail: "#{context[:delegator_email]}", delegateEmail: "#{
+        context[:delegate_email]
+      }") {
+          proposalUrl
+        }
+      }
+      """
+
+      {:ok, %{data: %{"deleteDelegation" => delegation}}} =
+        Absinthe.run(query, Schema, context: %{organization_id: context[:organization_id]})
+
+      assert delegation["proposalUrl"] == "https://propsals.com/p1"
+
+    end
+
     test "when delegation doesn't exist", context do
       query = """
       mutation {

--- a/test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs
@@ -117,6 +117,8 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.DeleteDelegationTest do
 
     # test case where a proposal-specific delegation already exists and we wish to delete an
     # existing global delegation for the same delegator & delegate.
+    # NOTE: this case should not occur when we prevent global AND proposal-specific delegations
+    # existing simultaneously for same delegator/delegate pair.
     test "when a similar proposal-specific delegation exists", context do
       query = """
       mutation {

--- a/test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs
@@ -129,7 +129,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.DeleteDelegationTest do
       {:ok, %{data: %{"deleteDelegation" => delegation}}} =
         Absinthe.run(query2, Schema, context: %{organization_id: context[:organization_id]})
 
-      assert delegation["proposalUrl"] != "https://proposal.com/1"
+      assert delegation["proposalUrl"] != original_delegation["proposalUrl"]
     end
 
     test "when delegation doesn't exist", context do

--- a/test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs
@@ -117,7 +117,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.DeleteDelegationTest do
 
     # test case where a proposal-specific delegation already exists and we wish to delete an
     # existing global delegation for the same delegator & delegate.
-    # NOTE: this case should not occur when we prevent global AND proposal-specific delegations
+    # NOTE: this case should never occur when we prevent global AND proposal-specific delegations
     # existing simultaneously for same delegator/delegate pair.
     test "when a similar proposal-specific delegation exists", context do
       query = """

--- a/test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs
@@ -100,36 +100,18 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.DeleteDelegationTest do
     end
 
     test "when a similar proposal-specific delegation exists", context do
-      # test case where a proposal-specific delegation already exists and we wish to delete
-      # a global delegation (if one exists) for the same delegator & delegate.
-
-      # first, create a proposal-specific delegation
-      query1 = """
+      query = """
       mutation {
-        createDelegation(delegatorEmail: "delegator@email.com", delegateEmail: "delegate@email.com", proposalUrl: "https://proposal.com/1") {
-          proposalUrl
-        }
-      }
-      """
-
-      {:ok, %{data: %{"createDelegation" => original_delegation}}} =
-        Absinthe.run(query1, Schema, context: %{organization_id: context[:organization_id]})
-
-      assert original_delegation["proposalUrl"] == "https://proposal.com/1"
-
-      # now delete delegation, using same details as above, except without proposalUrl field:
-      query2 = """
-      mutation {
-        deleteDelegation(delegatorEmail: "delegator@email.com", delegateEmail: "delegate@email.com") {
+        deleteDelegation(delegatorEmail: "#{context[:delegator_email]}", delegateEmail: "#{context[:delegate_email]}") {
           proposalUrl
         }
       }
       """
 
       {:ok, %{data: %{"deleteDelegation" => delegation}}} =
-        Absinthe.run(query2, Schema, context: %{organization_id: context[:organization_id]})
+        Absinthe.run(query, Schema, context: %{organization_id: context[:organization_id]})
 
-      assert delegation["proposalUrl"] != original_delegation["proposalUrl"]
+      assert delegation["proposalUrl"] != context[:proposal_url]
     end
 
     test "when delegation doesn't exist", context do

--- a/test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs
@@ -104,33 +104,32 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.DeleteDelegationTest do
       # a global delegation (if one exists) for the same delegator & delegate.
 
       # first, create a proposal-specific delegation
-      # (should be some way to do this without using actual absinthe mutation)
-      query = """
+      query1 = """
       mutation {
-        createDelegation(delegatorEmail: "#{context[:delegator_email]}", delegateEmail: "#{context[:delegate_email]}", proposalUrl: "https://proposals.com/p1") {
-          id
+        createDelegation(delegatorEmail: "delegator@email.com", delegateEmail: "delegate@email.com", proposalUrl: "https://proposal.com/1") {
+          proposalUrl
         }
       }
       """
 
-      {:ok, %{}}
+      {:ok, %{data: %{"createDelegation" => original_delegation}}} =
+        Absinthe.run(query1, Schema, context: %{organization_id: context[:organization_id]})
+
+      assert original_delegation["proposalUrl"] == "https://proposal.com/1"
 
       # now delete delegation, using same details as above, except without proposalUrl field:
-      query = """
+      query2 = """
       mutation {
-        deleteDelegation(delegatorEmail: "#{context[:delegator_email]}", delegateEmail: "#{
-        context[:delegate_email]
-      }") {
+        deleteDelegation(delegatorEmail: "delegator@email.com", delegateEmail: "delegate@email.com") {
           proposalUrl
         }
       }
       """
 
       {:ok, %{data: %{"deleteDelegation" => delegation}}} =
-        Absinthe.run(query, Schema, context: %{organization_id: context[:organization_id]})
+        Absinthe.run(query2, Schema, context: %{organization_id: context[:organization_id]})
 
-      assert delegation["proposalUrl"] != "https://proposals.com/p1"
-
+      assert delegation["proposalUrl"] != "https://proposal.com/1"
     end
 
     test "when delegation doesn't exist", context do

--- a/test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs
@@ -110,7 +110,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.DeleteDelegationTest do
       # first, create a proposal-specific delegation
       query1 = """
       mutation {
-        createDelegation(delegatorEmail: "#{context[:delegator_email]}", delegateEmail: "#{context[:delegate_email]}", proposalUrl: "#{context[:proposal_url]}") {
+        createDelegation(delegatorEmail: "delegator@email.com", delegateEmail: "delegate@email.com", proposalUrl: "#{context[:proposal_url]}") {
           proposalUrl
         }
       }
@@ -125,7 +125,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.DeleteDelegationTest do
       # now delete delegation, using same details as above, except without proposalUrl field:
       query2 = """
       mutation {
-        deleteDelegation(delegatorEmail: "#{context[:delegator_email]}", delegateEmail: "#{context[:delegate_email]}") {
+        deleteDelegation(delegatorEmail: "delegator@email.com", delegateEmail: "delegate@email.com") {
           proposalUrl
         }
       }


### PR DESCRIPTION
I'm having a mental blank here. I have created a test, but I have used a graphQL mutation to create a delegation before I then delete it. Please see test/liquid_voting_web/absinthe/mutations/delete_delegation_test.exs   
I would like to insert the delegation without using a graphQL mutation, but can't think how to do it. The created mutation needs to be proposal specific and I need to be able to use the field values from the created delegation in the delete delegation mutation. How can I do this? Thanks!