### PR TITLE
Resolve conflicts for delegations with same participants

### DIFF
--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -172,25 +172,26 @@ defmodule LiquidVoting.Delegations do
   def upsert_delegation(%{delegator_id: delegator_id} = attrs) do
     proposal_url = Map.get(attrs, :proposal_url)
 
-    # delegations = all delegations for delegator
-    #   search delegations for any with SAME DELEGATE
-    #     if find global and trying to create proposal
-    #       return error -> "global delegation already exists"
-    #     if find proposal(s) and trying to create global
-    #       delete all proposals found & create global
+    # Delegations = all delegations for delegator
+    #
+    #  search Delegations for any with SAME DELEGATE
+    #    if find global and trying to create proposal
+    #      return error -> "global delegation already exists"
+    #    if find proposal(s) and trying to create global
+    #      create new global delegation & delete all proposals found
     #  next (keep the existing functionality):
-    #     if trying to create global
-    #       search delegations for ANY GLOBAL
-    #         if found (should only be one or none)
-    #           update
-    #         else
-    #           create new delegation 
-    #     if trying to create proposal
-    #       search delegations for SAME PROPOSAL
-    #         if found (should only be one or none)
-    #           update
-    #         else
-    #           create new delegation
+    #    if trying to create global
+    #      search Delegations for ANY GLOBAL
+    #        if found (should only be one or none)
+    #          update
+    #        else
+    #          create new delegation 
+    #    if trying to create proposal
+    #      search delegations for SAME PROPOSAL
+    #        if found (should only be one or none)
+    #          update
+    #        else
+    #          create new delegation
 
     Delegation
     |> where([d], d.delegator_id == ^delegator_id)

--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -175,23 +175,23 @@ defmodule LiquidVoting.Delegations do
     # Delegations = all delegations for delegator
     #
     #  if trying to create proposal delegation
-    #    search Delegations for any proposal delegations with SAME DELEGATE
-    #      if find global in Delegations
+    #    search Delegations for any global delegation with SAME DELEGATE (should be one or none)    
+    #      if find global delegation
     #        return error -> "global delegation already exists"
-    #  if trying to create global
-    #    search Delegations for any global delegation with SAME DELEGATE (should be one or none)
-    #      if find proposal(s) in Delegations
+    #  if trying to create global delegation
+    #    search Delegations for any proposal delegations with SAME DELEGATE
+    #      if find proposal(s) delegations
     #       delete all proposal delegations found
     #
     #  next (keep the existing functionality):
     #    if trying to create global delegation
-    #      search Delegations for ANY GLOBAL
+    #      search Delegations for ANY GLOBAL dlegation
     #        if found (should only be one or none)
     #          update
     #        else
     #          create new delegation 
     #    if trying to create proposal delegation
-    #      search Delegations for SAME PROPOSAL
+    #      search Delegations for SAME PROPOSAL delegation
     #        if found (should only be one or none)
     #          update
     #        else
@@ -229,13 +229,14 @@ defmodule LiquidVoting.Delegations do
   defp resolve_conflicts(delegations, delegate_id, proposal_url) do
     delegations =
       case proposal_url do
-        #  if trying to create global
-        #    search Delegations for any global delegation with SAME DELEGATE (should be one or none)
-        #      if find proposal(s) in Delegations
+        #  if trying to create global delegation
+        #    search Delegations for any proposal delegations with SAME DELEGATE
+        #      if find proposal(s) delegations
         #       delete all proposal delegations found
-        nil ->
-          IO.puts("global case")
 
+        # case: attempting to create global delegation
+        nil ->
+          # find any proposal delegations with SAME DELEGATE
           same_delegate_proposal_delegations =
             Enum.filter(delegations, fn d ->
               d.proposal_url != nil and d.delegate_id == delegate_id
@@ -253,8 +254,8 @@ defmodule LiquidVoting.Delegations do
           end
 
         #  if trying to create proposal delegation
-        #    search Delegations for any proposal delegations with SAME DELEGATE
-        #      if find global in Delegations
+        #    search Delegations for any global delegation with SAME DELEGATE (should be one or none)    
+        #      if find global delegation
         #        return error -> "global delegation already exists"
         _proposal_url ->
           IO.puts("proposal case")

--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -202,8 +202,8 @@ defmodule LiquidVoting.Delegations do
     |> Repo.all()
     |> resolve_conflicts(delegate_id, proposal_url)
     |> case do
-      {:ok, delegations} -> delegations
-      # Find delegations of same type as in attrs (global vs proposal) for same delegator
+      {:ok, delegations_of_delegator} -> delegations_of_delegator
+      # Search for delegations of same type as in attrs (global vs proposal) for same delegator
       |> Enum.filter(fn d ->
         d.delegator_id == delegator_id and d.proposal_url == proposal_url
       end)
@@ -220,13 +220,13 @@ defmodule LiquidVoting.Delegations do
     end
   end
 
-  defp resolve_conflicts(delegations, delegate_id, _proposal_url = nil) do
-    #  When attemting global delegation creation:
+  defp resolve_conflicts(delegations_of_delegator, delegate_id, _proposal_url = nil) do
+    #  When attempting global delegation creation:
     #    Search Delegations for any proposal delegations with SAME DELEGATE
     #    and delete all proposal delegations found
 
     # same_delegate_proposal_delegations =
-    delegations
+    delegations_of_delegator
     |> Stream.filter(fn d ->
       d.proposal_url != nil and d.delegate_id == delegate_id
     end)
@@ -234,16 +234,16 @@ defmodule LiquidVoting.Delegations do
       delete_delegation!(d)
     end)
 
-    {:ok, delegations}
+    {:ok, delegations_of_delegator}
   end
 
-  defp resolve_conflicts(delegations, delegate_id, proposal_url) do
+  defp resolve_conflicts(delegations_of_delegator, delegate_id, proposal_url) do
     #  When attempting proposal-specific delegation creation
     #    search Delegations for any global delegation with SAME DELEGATE (should be one or none)    
     #      if find global delegation
     #        return error -> "global delegation already exists"
     IO.puts("proposal case")
-    {:ok, delegations}
+    {:ok, delegations_of_delegator}
   end
 
   @doc """

--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -162,6 +162,9 @@ defmodule LiquidVoting.Delegations do
 
   Creates a new delegation if neither aforementioned condition is true.
 
+  Also resolves conflicts with existing delegations for same delegator and
+  delegate as those passed in.
+
   ## Examples
 
       iex> upsert_delegation(%{

--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -162,8 +162,7 @@ defmodule LiquidVoting.Delegations do
 
   Creates a new delegation if neither aforementioned condition is true.
 
-  Also resolves conflicts with existing delegations for same delegator and
-  delegate as those passed in.
+  Also resolves conflicts with existing delegations.
 
   ## Examples
 
@@ -197,21 +196,15 @@ defmodule LiquidVoting.Delegations do
     end
   end
 
-  # Resolves conflicting delegations for same delegator and delegate (2 clauses).
+  # Resolves conflicting delegations (2 clauses).
   #
   # Used by upsert_delegation/1 (above).
   #
   # Clause 1: Matches an attempt to upsert a global delegation.
-  #
-  # Searches list of delegations for the specified delegator for any
-  # proposal-specific delegations to the same delegate in the attributes passed
-  # into upsert_delegation/1. and deletes any such delegations found.
+  # Looks for conflicting proposal-specific delegations and deletes any found.
   #
   # Clause 2: Matches an attempt to upsert a proposal-specific delegation.
-  #
-  # Searches list of delegations for the specified delegator for global delegation
-  # to the same delegate in the attributes passed into upsert_delegation/1 and
-  # returns an error if such a delegation is found.
+  # Looks for conflicting global delegation, and returns an error if found.
   defp resolve_conflicts(delegations_of_delegator, delegate_id, _proposal_url = nil) do
     delegations_of_delegator
     |> Stream.filter(fn d ->
@@ -242,12 +235,9 @@ defmodule LiquidVoting.Delegations do
     end
   end
 
-  # Searches the list of delegations for the specified delegator for delegations
-  # of the same type (global or for the same specific proposal) as in the
-  # attributes passed into upsert_delegation/1.
-  #
-  # Returns a matching delegation type, if found, or returns an empty Delegation
-  # struct.
+  # Looks for a delegator's existing delegation of matching type (global or for
+  # same proposal).Returns a matching delegation type, if found, or returns an
+  #  empty Delegation struct.
   #
   # Used by upsert_delegation/1 (above.)
   defp find_similar_delegation_or_return_new_struct(delegations_of_delegator, proposal_url) do

--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -195,17 +195,14 @@ defmodule LiquidVoting.Delegations do
     #        else
     #          create new delegation
 
+    _delegations =
+      Delegation
+      |> where(delegator_id: ^delegator_id)
+      |> Repo.all()
+      |> resolve_conflicts(proposal_url)
 
-    _delegations = Delegation
-    |> where(delegator_id: ^delegator_id)
-    |> Repo.all()
-    |> resolve_conflicts(proposal_url)
-    #|> IO.inspect()
-    #|> Enum.filter(fn(d) -> d.proposal_url == nil end) # DEBUG
-
-
-
-
+    # |> IO.inspect()
+    # |> Enum.filter(fn(d) -> d.proposal_url == nil end) # DEBUG
 
     Delegation
     |> where([d], d.delegator_id == ^delegator_id)
@@ -229,15 +226,15 @@ defmodule LiquidVoting.Delegations do
 
   defp resolve_conflicts(delegations, proposal_url) do
     case proposal_url do
+      # if trying to create global
+      #   if find proposal(s) in Delegations
+      #     delete all proposal delegations found
+      nil -> IO.puts("global case")
+      
       # if trying to create proposal delegation
       #   if find global in Delegations
       #     return error -> "global delegation already exists"
-      nil -> IO.puts "global case"
-
-    # if trying to create proposal delegation
-    #   if find global in Delegations
-    #     return error -> "global delegation already exists"
-      _proposal_url -> IO.puts "proposal case"
+      _proposal_url -> IO.puts("proposal case")
     end
 
     delegations

--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -237,7 +237,7 @@ defmodule LiquidVoting.Delegations do
 
     delegations_of_delegator
     |> Stream.filter(fn d ->
-      d.proposal_url != nil and d.delegate_id == delegate_id
+      d.delegate_id == delegate_id and d.proposal_url != nil
     end)
     |> Enum.each(fn d ->
       delete_delegation!(d)
@@ -250,7 +250,7 @@ defmodule LiquidVoting.Delegations do
     #  When attempting proposal-specific delegation creation
     #    search Delegations for any global delegation with SAME DELEGATE (should be one or none)    
     #      if find global delegation
-    #        return error -> "global delegation already exists"
+    #        return error
 
     delegations_of_delegator
     |> Enum.filter(fn d ->
@@ -268,10 +268,6 @@ defmodule LiquidVoting.Delegations do
          }}
     end
   end
-
-  # {:ok, %{errors: [%{message: message, details: details}]}}
-  # This is what is recieved by working test: create delegation with existing delegator and delegate with missing field
-  # LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegatorDelegateTest
 
   @doc """
   Updates a delegation.

--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -175,10 +175,12 @@ defmodule LiquidVoting.Delegations do
     # Delegations = all delegations for delegator
     #
     #  search Delegations for any with SAME DELEGATE
-    #    if find global and trying to create proposal delegation
-    #      return error -> "global delegation already exists"
-    #    if find proposal(s) and trying to create global
-    #      delete all proposal delegations found
+    #    if trying to create proposal delegation
+    #      if find global in Delegations
+    #        return error -> "global delegation already exists"
+    #    if trying to create global
+    #      if find proposal(s) in Delegations
+    #       delete all proposal delegations found
     #  next (keep the existing functionality):
     #    if trying to create global delegation
     #      search Delegations for ANY GLOBAL
@@ -187,11 +189,23 @@ defmodule LiquidVoting.Delegations do
     #        else
     #          create new delegation 
     #    if trying to create proposal delegation
-    #      search delegations for SAME PROPOSAL
+    #      search Delegations for SAME PROPOSAL
     #        if found (should only be one or none)
     #          update
     #        else
     #          create new delegation
+
+
+    _delegations = Delegation
+    |> where(delegator_id: ^delegator_id)
+    |> Repo.all()
+    |> resolve_conflicts(proposal_url)
+    #|> IO.inspect()
+    #|> Enum.filter(fn(d) -> d.proposal_url == nil end) # DEBUG
+
+
+
+
 
     Delegation
     |> where([d], d.delegator_id == ^delegator_id)
@@ -212,6 +226,22 @@ defmodule LiquidVoting.Delegations do
 
   defp where_proposal(query, proposal_url),
     do: query |> where([d], d.proposal_url == ^proposal_url)
+
+  defp resolve_conflicts(delegations, proposal_url) do
+    case proposal_url do
+      # if trying to create proposal delegation
+      #   if find global in Delegations
+      #     return error -> "global delegation already exists"
+      nil -> IO.puts "global case"
+
+    # if trying to create proposal delegation
+    #   if find global in Delegations
+    #     return error -> "global delegation already exists"
+      _proposal_url -> IO.puts "proposal case"
+    end
+
+    delegations
+  end
 
   @doc """
   Updates a delegation.

--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -175,18 +175,18 @@ defmodule LiquidVoting.Delegations do
     # Delegations = all delegations for delegator
     #
     #  search Delegations for any with SAME DELEGATE
-    #    if find global and trying to create proposal
+    #    if find global and trying to create proposal delegation
     #      return error -> "global delegation already exists"
     #    if find proposal(s) and trying to create global
-    #      create new global delegation & delete all proposals found
+    #      delete all proposal delegations found
     #  next (keep the existing functionality):
-    #    if trying to create global
+    #    if trying to create global delegation
     #      search Delegations for ANY GLOBAL
     #        if found (should only be one or none)
     #          update
     #        else
     #          create new delegation 
-    #    if trying to create proposal
+    #    if trying to create proposal delegation
     #      search delegations for SAME PROPOSAL
     #        if found (should only be one or none)
     #          update

--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -203,7 +203,7 @@ defmodule LiquidVoting.Delegations do
     |> resolve_conflicts(delegate_id, proposal_url)
     |> case do
       {:ok, delegations_of_delegator} -> delegations_of_delegator
-      # Search for delegations of same type as in attrs (global vs proposal) for same delegator
+      # Search delegations_of_delegator for delegations of same type as in attrs (global vs proposal)
       |> Enum.filter(fn d ->
         d.delegator_id == delegator_id and d.proposal_url == proposal_url
       end)
@@ -225,7 +225,6 @@ defmodule LiquidVoting.Delegations do
     #    Search Delegations for any proposal delegations with SAME DELEGATE
     #    and delete all proposal delegations found
 
-    # same_delegate_proposal_delegations =
     delegations_of_delegator
     |> Stream.filter(fn d ->
       d.proposal_url != nil and d.delegate_id == delegate_id
@@ -242,8 +241,15 @@ defmodule LiquidVoting.Delegations do
     #    search Delegations for any global delegation with SAME DELEGATE (should be one or none)    
     #      if find global delegation
     #        return error -> "global delegation already exists"
-    IO.puts("proposal case")
-    {:ok, delegations_of_delegator}
+
+    delegations_of_delegator
+    |> Enum.filter(fn d ->
+      d.proposal_url == nil and d.delegate_id == delegate_id
+    end)
+    |> case do
+      [] -> {:ok, delegations_of_delegator}
+      _found_global -> IO.puts("Found GLOBAL in proposal case")
+    end
   end
 
   @doc """

--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -172,6 +172,26 @@ defmodule LiquidVoting.Delegations do
   def upsert_delegation(%{delegator_id: delegator_id} = attrs) do
     proposal_url = Map.get(attrs, :proposal_url)
 
+    # delegations = all delegations for delegator
+    #   search delegations for any with SAME DELEGATE
+    #     if find global and trying to create proposal
+    #       return error -> "global delegation already exists"
+    #     if find proposal(s) and trying to create global
+    #       delete all proposals found & create global
+    #  next (keep the existing functionality):
+    #     if trying to create global
+    #       search delegations for ANY GLOBAL
+    #         if found (should only be one or none)
+    #           update
+    #         else
+    #           create new delegation 
+    #     if trying to create proposal
+    #       search delegations for SAME PROPOSAL
+    #         if found (should only be one or none)
+    #           update
+    #         else
+    #           create new delegation
+
     Delegation
     |> where([d], d.delegator_id == ^delegator_id)
     |> where_proposal(proposal_url)

--- a/lib/liquid_voting/delegations.ex
+++ b/lib/liquid_voting/delegations.ex
@@ -226,41 +226,28 @@ defmodule LiquidVoting.Delegations do
   defp where_proposal(query, proposal_url),
     do: query |> where([d], d.proposal_url == ^proposal_url)
 
+  defp resolve_conflicts(delegations, delegate_id, proposal_url = nil) do
+    #  if trying to create global delegation
+    #    search Delegations for any proposal delegations with SAME DELEGATE
+    #      if find proposal(s) delegations
+    #       delete all proposal delegations found
+    same_delegate_proposal_delegations =
+      Enum.filter(delegations, fn d ->
+        d.proposal_url != nil and d.delegate_id == delegate_id
+      end)
+
+    Enum.each(same_delegate_proposal_delegations, fn d ->
+      IO.puts("FOUND PROPOSAL TO DELETE!!!")
+      delete_delegation!(d)
+    end)
+  end
+
   defp resolve_conflicts(delegations, delegate_id, proposal_url) do
-    delegations =
-      case proposal_url do
-        #  if trying to create global delegation
-        #    search Delegations for any proposal delegations with SAME DELEGATE
-        #      if find proposal(s) delegations
-        #       delete all proposal delegations found
-
-        # case: attempting to create global delegation
-        nil ->
-          # find any proposal delegations with SAME DELEGATE
-          same_delegate_proposal_delegations =
-            Enum.filter(delegations, fn d ->
-              d.proposal_url != nil and d.delegate_id == delegate_id
-            end)
-
-          cond do
-            same_delegate_proposal_delegations != [] ->
-              IO.puts("FOUND PROPOSAL(S) TO DELETE!!!")
-              IO.puts("***********************")
-              IO.inspect(same_delegate_proposal_delegations)
-              IO.puts("***********************")
-
-            true ->
-              delegations
-          end
-
-        #  if trying to create proposal delegation
-        #    search Delegations for any global delegation with SAME DELEGATE (should be one or none)    
-        #      if find global delegation
-        #        return error -> "global delegation already exists"
-        _proposal_url ->
-          IO.puts("proposal case")
-      end
-
+    #  if trying to create proposal delegation
+    #    search Delegations for any global delegation with SAME DELEGATE (should be one or none)    
+    #      if find global delegation
+    #        return error -> "global delegation already exists"
+    IO.puts("proposal case")
     delegations
   end
 

--- a/test/liquid_voting/delegations_test.exs
+++ b/test/liquid_voting/delegations_test.exs
@@ -208,7 +208,7 @@ defmodule LiquidVoting.DelegationsTest do
       assert original_delegation.delegator_id == modified_delegation.delegator_id
     end
 
-    test "upsert_delegation/1 with duplicate global delegation does nothing" do
+    test "upsert_delegation/1 with duplicate global returns the original delegation" do
       original_delegation = insert(:delegation)
 
       args = %{

--- a/test/liquid_voting_web/absinthe/mutations/create_delegation/existing_delegations_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/create_delegation/existing_delegations_test.exs
@@ -235,7 +235,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
       """
 
       # TODO: Improve structure of error returned to absinthe (this is way too messy)
-      {:ok, %{data: %{}, errors: [%{details: details, message: message}]}} =
+      {:ok, %{errors: [%{details: details, message: message}]}} =
         Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
 
       assert message == "Could not create delegation."

--- a/test/liquid_voting_web/absinthe/mutations/create_delegation/existing_delegations_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/create_delegation/existing_delegations_test.exs
@@ -38,12 +38,12 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
 
   describe "create global delegation when proposal delegation to same delegate already exists" do
     test "returns the new global delegation" do
-      proposal_delegation_1 = insert(:delegation_for_proposal)
+      proposal_delegation = insert(:delegation_for_proposal)
 
       query = """
       mutation {
-        createDelegation(delegatorEmail: "#{proposal_delegation_1.delegator.email}", delegateEmail: "#{
-        proposal_delegation_1.delegate.email
+        createDelegation(delegatorEmail: "#{proposal_delegation.delegator.email}", delegateEmail: "#{
+        proposal_delegation.delegate.email
       }") {
           delegator {
             email
@@ -57,11 +57,11 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
 
       {:ok, %{data: %{"createDelegation" => global_delegation}}} =
         Absinthe.run(query, Schema,
-          context: %{organization_id: proposal_delegation_1.organization_id}
+          context: %{organization_id: proposal_delegation.organization_id}
         )
 
-      assert global_delegation["delegator"]["email"] == proposal_delegation_1.delegator.email
-      assert global_delegation["delegate"]["email"] == proposal_delegation_1.delegate.email
+      assert global_delegation["delegator"]["email"] == proposal_delegation.delegator.email
+      assert global_delegation["delegate"]["email"] == proposal_delegation.delegate.email
     end
   end
 
@@ -82,6 +82,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
             email
           }
           proposalUrl
+          id
         }
       }
       """
@@ -94,6 +95,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
       assert updated_delegation["delegator"]["email"] == proposal_delegation.delegator.email
       assert updated_delegation["delegate"]["email"] == another_delegate.email
       assert updated_delegation["proposalUrl"] == proposal_delegation.proposal_url
+      assert updated_delegation["id"] == proposal_delegation.id
     end
   end
 

--- a/test/liquid_voting_web/absinthe/mutations/create_delegation/existing_delegations_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/create_delegation/existing_delegations_test.exs
@@ -67,7 +67,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
       ]
     end
 
-    test "deletes proposal specific delegations for same delegator/delegate pair", context do
+    test "returns the new global delegation", context do
       # Third, create a global delegation for the same participants.
       query = """
       mutation {
@@ -90,32 +90,6 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
 
       assert global_delegation["delegator"]["email"] == context[:delegator].email
       assert global_delegation["delegate"]["email"] == context[:delegate].email
-
-      # Fourth, search for proposal_delegation_1 (should return error).
-      query = """
-      query {
-        delegation(id: "#{context[:proposal_delegation_1_id]}") {
-          id
-        }
-      }
-      """
-
-      assert_raise Ecto.NoResultsError, fn ->
-        Absinthe.run(query, Schema, context: %{organization_id: context[:organization_id]})
-      end
-
-      # Lastly, search for proposal_delegation_2 (should return error).
-      query = """
-      query {
-        delegation(id: "#{context[:proposal_delegation_2_id]}") {
-          id
-        }
-      }
-      """
-
-      assert_raise Ecto.NoResultsError, fn ->
-        Absinthe.run(query, Schema, context: %{organization_id: context[:organization_id]})
-      end
     end
   end
 

--- a/test/liquid_voting_web/absinthe/mutations/create_delegation/existing_delegations_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/create_delegation/existing_delegations_test.exs
@@ -10,7 +10,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
   @another_proposal_url "https://www.proposal.com/another"
   @organization_id Ecto.UUID.generate()
 
-  describe "create global delegation for delegator with existing global delegation to different delegate" do
+  describe "create global delegation when a global delegation for a different delegate already exists" do
     test "overwrites existing global delegation" do
       query = """
       mutation {
@@ -58,7 +58,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
     end
   end
 
-  describe "create global delegation for delegator with existing proposal delegations to same delegate" do
+  describe "create global delegation when proposal delegations to same delegate already exist" do
     test "deletes proposal specific delegations for same delegator/delegate pair" do
       # First, create a proposal-specific delegation.
       query = """
@@ -142,7 +142,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
     end
   end
 
-  describe "create new proposal-specific delegation for delegator with existing delegation for same proposal" do
+  describe "create proposal delegation when delegation for same proposal already exists" do
     test "overwrites existing proposal-specific delegation" do
       query = """
       mutation {
@@ -191,7 +191,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
     end
   end
 
-  describe "create proposal delegation for delegator with existing global delegation to same delegate" do
+  describe "create proposal delegation when global delegation to same delegate already exists" do
     test "returns error" do
       # first, create a global delegation
       query = """
@@ -230,7 +230,6 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
       }
       """
 
-      # TODO: Improve structure of error returned to absinthe (this is way too messy)
       {:ok, %{errors: [%{details: details, message: message}]}} =
         Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
 

--- a/test/liquid_voting_web/absinthe/mutations/create_delegation/existing_delegations_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/create_delegation/existing_delegations_test.exs
@@ -60,7 +60,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
 
   describe "create global delegation for delegator with existing proposal delegations to same delegate" do
     test "deletes proposal specific delegations for same delegator/delegate pair" do
-      # first, create a proposal-specific delegation
+      # First, create a proposal-specific delegation.
       query = """
       mutation {
         createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{@delegate_email}", proposalUrl: "#{
@@ -77,7 +77,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
 
       assert proposal_delegation_1["proposalUrl"] == @proposal_url
 
-      # second, create another proposal-specific delegation (same participants, different proposalUrl)
+      # Second, create another proposal-specific delegation (same participants, different proposalUrl).
       query = """
       mutation {
         createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{@delegate_email}", proposalUrl: "#{
@@ -96,7 +96,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
 
       # TODO? Insert 3rd proposal-specific delegation to DIFFERENT delegate, for testing deletion of wrong delegations does not occur?
 
-      # third, create a global delegation for the same participants
+      # Third, create a global delegation for the same participants.
       query = """
       mutation {
         createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{@delegate_email}") {
@@ -116,7 +116,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
       assert global_delegation["delegator"]["email"] == @delegator_email
       assert global_delegation["delegate"]["email"] == @delegate_email
 
-      # fourth, search for proposal_delgation_1 (should return error)
+      # Fourth, search for proposal_delgation_1 (should return error).
       query = """
       query {
         delegation(id: "#{proposal_delegation_1["id"]}") {
@@ -125,13 +125,11 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
       }
       """
 
-      # TODO: Change to {:ok, %{errors: ...}} and assert specific error, when functionality created
-      {:ok, %{data: %{"delegation" => delegation}}} =
+      assert_raise Ecto.NoResultsError, fn ->
         Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
+      end
 
-      assert delegation["id"] != proposal_delegation_1["id"]
-
-      # lastly, search for proposal_delegation_2 (should return error)
+      # Lastly, search for proposal_delegation_2 (should return error).
       query = """
       query {
         delegation(id: "#{proposal_delegation_2["id"]}") {
@@ -140,11 +138,9 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
       }
       """
 
-      # TODO: Change to {:ok, %{errors: ...}} and assert specific error, when functionality created
-      {:ok, %{data: %{"delegation" => delegation}}} =
+      assert_raise Ecto.NoResultsError, fn ->
         Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
-
-      assert delegation["id"] != proposal_delegation_2["id"]
+      end
 
       # TODO? Search for 3rd proposal-specific delegation to DIFFERENT delegate, and assert can be found (not deleted)?
     end

--- a/test/liquid_voting_web/absinthe/mutations/create_delegation/existing_delegations_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/create_delegation/existing_delegations_test.exs
@@ -7,9 +7,10 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
   @delegate_email "delegate@email.com"
   @another_delegate_email "another-delegate@email.com"
   @proposal_url "https://www.proposal.com/my"
+  @another_proposal_url "https://www.proposal.com/another"
   @organization_id Ecto.UUID.generate()
 
-  describe "with existing global delegation" do
+  describe "create global delegation for delegator with existing global delegation to different delegate" do
     test "overwrites existing global delegation" do
       query = """
       mutation {
@@ -54,6 +55,98 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
 
       assert modified_delegation["delegator"]["email"] == @delegator_email
       assert modified_delegation["delegate"]["email"] == @another_delegate_email
+    end
+  end
+
+  describe "create global delegation for delegator with existing proposal delegations to same delegate" do
+    test "deletes proposal specific delegations for same delegator/delegate pair" do
+      # first, create a proposal-specific delegation
+      query = """
+      mutation {
+        createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{@delegate_email}", proposalUrl: "#{
+        @proposal_url
+      }") {
+          id
+          proposalUrl
+        }
+      }
+      """
+
+      {:ok, %{data: %{"createDelegation" => proposal_delegation_1}}} =
+        Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
+
+      assert proposal_delegation_1["proposalUrl"] == @proposal_url
+
+      # second, create another proposal-specific delegation (same participants, different proposalUrl)
+      query = """
+      mutation {
+        createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{@delegate_email}", proposalUrl: "#{
+        @another_proposal_url
+      }") {
+          id
+          proposalUrl
+        }
+      }
+      """
+
+      {:ok, %{data: %{"createDelegation" => proposal_delegation_2}}} =
+        Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
+
+      assert proposal_delegation_2["proposalUrl"] == @another_proposal_url
+
+      # TODO? Insert 3rd proposal-specific delegation to DIFFERENT delegate, for testing deletion of wrong delegations does not occur?
+
+      # third, create a global delegation for the same participants
+      query = """
+      mutation {
+        createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{@delegate_email}") {
+          delegator {
+            email
+          }
+          delegate {
+            email
+          }
+        }
+      }
+      """
+
+      {:ok, %{data: %{"createDelegation" => global_delegation}}} =
+        Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
+
+      assert global_delegation["delegator"]["email"] == @delegator_email
+      assert global_delegation["delegate"]["email"] == @delegate_email
+
+      # fourth, search for proposal_delgation_1 (should return error)
+      query = """
+      query {
+        delegation(id: "#{proposal_delegation_1["id"]}") {
+          id
+        }
+      }
+      """
+
+      # TODO: Change to {:ok, %{errors: ...}} and assert specific error, when functionality created
+      {:ok, %{data: %{"delegation" => delegation}}} =
+        Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
+
+      assert delegation["id"] != proposal_delegation_1["id"]
+
+      # lastly, search for proposal_delegation_2 (should return error)
+      query = """
+      query {
+        delegation(id: "#{proposal_delegation_2["id"]}") {
+          id
+        }
+      }
+      """
+
+      # TODO: Change to {:ok, %{errors: ...}} and assert specific error, when functionality created
+      {:ok, %{data: %{"delegation" => delegation}}} =
+        Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
+
+      assert delegation["id"] != proposal_delegation_2["id"]
+
+      # TODO? Search for 3rd proposal-specific delegation to DIFFERENT delegate, and assert can be found (not deleted)?
     end
   end
 
@@ -103,6 +196,54 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
       assert modified_delegation["delegator"]["email"] == @delegator_email
       assert modified_delegation["delegate"]["email"] == @another_delegate_email
       assert original_delegation["proposalUrl"] == modified_delegation["proposalUrl"]
+    end
+  end
+
+  describe "create proposal delegation for delegator with existing global delegation to same delegate" do
+    test "returns error" do
+      # first, create a global delegation
+      query = """
+      mutation {
+        createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{@delegate_email}") {
+          delegator {
+            email
+          }
+          delegate {
+            email
+          }
+        }
+      }
+      """
+
+      {:ok, %{data: %{"createDelegation" => original_delegation}}} =
+        Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
+
+      assert original_delegation["delegator"]["email"] == @delegator_email
+      assert original_delegation["delegate"]["email"] == @delegate_email
+
+      # then, attempt to create a proposal-specific delegation for same delegator and delegate
+      query = """
+      mutation {
+        createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{@delegate_email}", proposalUrl: "#{
+        @proposal_url
+      }") {
+          delegator {
+            email
+          }
+          delegate {
+            email
+          }
+          proposalUrl
+        }
+      }
+      """
+
+      # TODO: Change to {:ok, %{errors: ...}} and assert specific error, when functionality created
+      {:ok, %{data: %{"createDelegation" => new_delegation}}} =
+        Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
+
+      assert new_delegation["delegator"]["email"] != @delegator_email
+      assert new_delegation["delegate"]["email"] != @delegate_email
     end
   end
 end

--- a/test/liquid_voting_web/absinthe/mutations/create_delegation/existing_delegations_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/create_delegation/existing_delegations_test.exs
@@ -234,12 +234,12 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
       }
       """
 
-      # TODO: Change to {:ok, %{errors: ...}} and assert specific error, when functionality created
-      {:ok, %{data: %{"createDelegation" => new_delegation}}} =
+      # TODO: Improve structure of error returned to absinthe (this is way too messy)
+      {:ok, %{data: %{}, errors: [%{details: details, message: message}]}} =
         Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
 
-      assert new_delegation["delegator"]["email"] != @delegator_email
-      assert new_delegation["delegate"]["email"] != @delegate_email
+      assert message == "Could not create delegation."
+      assert details == "A global delegation for the same participants already exists."
     end
   end
 end

--- a/test/liquid_voting_web/absinthe/mutations/create_delegation/existing_delegations_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/create_delegation/existing_delegations_test.exs
@@ -1,42 +1,27 @@
 defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegationsTest do
   use LiquidVotingWeb.ConnCase
+  import LiquidVoting.Factory
 
   alias LiquidVotingWeb.Schema.Schema
 
-  @delegator_email "delegator@email.com"
-  @delegate_email "delegate@email.com"
-  @another_delegate_email "another-delegate@email.com"
-  @proposal_url "https://www.proposal.com/my"
-  @another_proposal_url "https://www.proposal.com/another"
-  @organization_id Ecto.UUID.generate()
-
   describe "create global delegation when a global delegation for a different delegate already exists" do
-    test "overwrites existing global delegation" do
+    setup do
+      global_delegation = insert(:delegation)
+      another_delegate = insert(:participant)
+
+      [
+        organization_id: global_delegation.organization_id,
+        global_delegation_id: global_delegation.id,
+        delegator: global_delegation.delegator,
+        another_delegate: another_delegate
+      ]
+    end
+
+    test "overwrites existing global delegation", context do
       query = """
       mutation {
-        createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{@delegate_email}") {
-          delegator {
-            email
-            name
-          }
-          delegate {
-            email
-            name
-          }
-        }
-      }
-      """
-
-      {:ok, %{data: %{"createDelegation" => original_delegation}}} =
-        Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
-
-      assert original_delegation["delegator"]["email"] == @delegator_email
-      assert original_delegation["delegate"]["email"] == @delegate_email
-
-      query = """
-      mutation {
-        createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{
-        @another_delegate_email
+        createDelegation(delegatorEmail: "#{context[:delegator].email}", delegateEmail: "#{
+        context[:another_delegate].email
       }") {
           delegator {
             email
@@ -46,109 +31,113 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
             email
             name
           }
+          id
         }
       }
       """
 
-      {:ok, %{data: %{"createDelegation" => modified_delegation}}} =
-        Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
+      {:ok, %{data: %{"createDelegation" => updated_delegation}}} =
+        Absinthe.run(query, Schema, context: %{organization_id: context[:organization_id]})
 
-      assert modified_delegation["delegator"]["email"] == @delegator_email
-      assert modified_delegation["delegate"]["email"] == @another_delegate_email
+      assert updated_delegation["delegator"]["email"] == context[:delegator].email
+      assert updated_delegation["delegate"]["email"] == context[:another_delegate].email
+      assert updated_delegation["id"] == context[:global_delegation_id]
     end
   end
 
   describe "create global delegation when proposal delegations to same delegate already exist" do
-    test "deletes proposal specific delegations for same delegator/delegate pair" do
+    setup do
       # First, create a proposal-specific delegation.
-      query = """
-      mutation {
-        createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{@delegate_email}", proposalUrl: "#{
-        @proposal_url
-      }") {
-          id
-          proposalUrl
-        }
-      }
-      """
+      proposal_delegation_1 = insert(:delegation_for_proposal)
 
-      {:ok, %{data: %{"createDelegation" => proposal_delegation_1}}} =
-        Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
+      # Second, create another proposal-specific delegation (same participants & organization, different proposalUrl).
+      proposal_delegation_2 =
+        insert(:delegation_for_proposal,
+          delegator: proposal_delegation_1.delegator,
+          delegate: proposal_delegation_1.delegate,
+          organization_id: proposal_delegation_1.organization_id
+        )
 
-      assert proposal_delegation_1["proposalUrl"] == @proposal_url
+      [
+        organization_id: proposal_delegation_1.organization_id,
+        delegator: proposal_delegation_1.delegator,
+        delegate: proposal_delegation_1.delegate,
+        proposal_delegation_1_id: proposal_delegation_1.id,
+        proposal_delegation_2_id: proposal_delegation_2.id
+      ]
+    end
 
-      # Second, create another proposal-specific delegation (same participants, different proposalUrl).
-      query = """
-      mutation {
-        createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{@delegate_email}", proposalUrl: "#{
-        @another_proposal_url
-      }") {
-          id
-          proposalUrl
-        }
-      }
-      """
-
-      {:ok, %{data: %{"createDelegation" => proposal_delegation_2}}} =
-        Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
-
-      assert proposal_delegation_2["proposalUrl"] == @another_proposal_url
-
+    test "deletes proposal specific delegations for same delegator/delegate pair", context do
       # Third, create a global delegation for the same participants.
       query = """
       mutation {
-        createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{@delegate_email}") {
+        createDelegation(delegatorEmail: "#{context[:delegator].email}", delegateEmail: "#{
+        context[:delegate].email
+      }") {
           delegator {
             email
           }
           delegate {
             email
           }
+          id
         }
       }
       """
 
       {:ok, %{data: %{"createDelegation" => global_delegation}}} =
-        Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
+        Absinthe.run(query, Schema, context: %{organization_id: context[:organization_id]})
 
-      assert global_delegation["delegator"]["email"] == @delegator_email
-      assert global_delegation["delegate"]["email"] == @delegate_email
+      assert global_delegation["delegator"]["email"] == context[:delegator].email
+      assert global_delegation["delegate"]["email"] == context[:delegate].email
 
-      # Fourth, search for proposal_delgation_1 (should return error).
+      # Fourth, search for proposal_delegation_1 (should return error).
       query = """
       query {
-        delegation(id: "#{proposal_delegation_1["id"]}") {
+        delegation(id: "#{context[:proposal_delegation_1_id]}") {
           id
         }
       }
       """
 
       assert_raise Ecto.NoResultsError, fn ->
-        Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
+        Absinthe.run(query, Schema, context: %{organization_id: context[:organization_id]})
       end
 
       # Lastly, search for proposal_delegation_2 (should return error).
       query = """
       query {
-        delegation(id: "#{proposal_delegation_2["id"]}") {
+        delegation(id: "#{context[:proposal_delegation_2_id]}") {
           id
         }
       }
       """
 
       assert_raise Ecto.NoResultsError, fn ->
-        Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
+        Absinthe.run(query, Schema, context: %{organization_id: context[:organization_id]})
       end
     end
   end
 
   describe "create proposal delegation when delegation for same proposal already exists" do
-    test "overwrites existing proposal-specific delegation" do
+    setup do
+      proposal_delegation = insert(:delegation_for_proposal)
+      another_delegate = insert(:participant)
+
+      [
+        organization_id: proposal_delegation.organization_id,
+        delegator: proposal_delegation.delegator,
+        proposal_url: proposal_delegation.proposal_url,
+        another_delegate: another_delegate
+      ]
+    end
+
+    test "overwrites existing proposal-specific delegation", context do
       query = """
       mutation {
-        createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{@delegate_email}", proposalUrl: "#{
-        @proposal_url
-      }") {
+        createDelegation(delegatorEmail: "#{context[:delegator].email}", delegateEmail: "#{
+        context[:another_delegate].email
+      }", proposalUrl: "#{context[:proposal_url]}") {
           delegator {
             email
           }
@@ -160,65 +149,32 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
       }
       """
 
-      {:ok, %{data: %{"createDelegation" => original_delegation}}} =
-        Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
+      {:ok, %{data: %{"createDelegation" => updated_delegation}}} =
+        Absinthe.run(query, Schema, context: %{organization_id: context[:organization_id]})
 
-      assert original_delegation["delegator"]["email"] == @delegator_email
-      assert original_delegation["delegate"]["email"] == @delegate_email
-
-      query = """
-      mutation {
-        createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{
-        @another_delegate_email
-      }", proposalUrl: "#{@proposal_url}") {
-          delegator {
-            email
-          }
-          delegate {
-            email
-          }
-          proposalUrl
-        }
-      }
-      """
-
-      {:ok, %{data: %{"createDelegation" => modified_delegation}}} =
-        Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
-
-      assert modified_delegation["delegator"]["email"] == @delegator_email
-      assert modified_delegation["delegate"]["email"] == @another_delegate_email
-      assert original_delegation["proposalUrl"] == modified_delegation["proposalUrl"]
+      assert updated_delegation["delegator"]["email"] == context[:delegator].email
+      assert updated_delegation["delegate"]["email"] == context[:another_delegate].email
+      assert updated_delegation["proposalUrl"] == context[:proposal_url]
     end
   end
 
   describe "create proposal delegation when global delegation to same delegate already exists" do
-    test "returns error" do
-      # first, create a global delegation
+    setup do
+      global_delegation = insert(:delegation)
+
+      [
+        organization_id: global_delegation.organization_id,
+        delegator: global_delegation.delegator,
+        delegate: global_delegation.delegate
+      ]
+    end
+
+    test "returns error", context do
       query = """
       mutation {
-        createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{@delegate_email}") {
-          delegator {
-            email
-          }
-          delegate {
-            email
-          }
-        }
-      }
-      """
-
-      {:ok, %{data: %{"createDelegation" => original_delegation}}} =
-        Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
-
-      assert original_delegation["delegator"]["email"] == @delegator_email
-      assert original_delegation["delegate"]["email"] == @delegate_email
-
-      # then, attempt to create a proposal-specific delegation for same delegator and delegate
-      query = """
-      mutation {
-        createDelegation(delegatorEmail: "#{@delegator_email}", delegateEmail: "#{@delegate_email}", proposalUrl: "#{
-        @proposal_url
-      }") {
+        createDelegation(delegatorEmail: "#{context[:delegator].email}", delegateEmail: "#{
+        context[:delegate].email
+      }", proposalUrl: "https://www.proposal.com/1") {
           delegator {
             email
           }
@@ -231,7 +187,7 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
       """
 
       {:ok, %{errors: [%{details: details, message: message}]}} =
-        Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
+        Absinthe.run(query, Schema, context: %{organization_id: context[:organization_id]})
 
       assert message == "Could not create delegation."
       assert details == "A global delegation for the same participants already exists."

--- a/test/liquid_voting_web/absinthe/mutations/create_delegation/existing_delegations_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/create_delegation/existing_delegations_test.exs
@@ -94,8 +94,6 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
 
       assert proposal_delegation_2["proposalUrl"] == @another_proposal_url
 
-      # TODO? Insert 3rd proposal-specific delegation to DIFFERENT delegate, for testing deletion of wrong delegations does not occur?
-
       # Third, create a global delegation for the same participants.
       query = """
       mutation {
@@ -141,8 +139,6 @@ defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.ExistingDelegation
       assert_raise Ecto.NoResultsError, fn ->
         Absinthe.run(query, Schema, context: %{organization_id: @organization_id})
       end
-
-      # TODO? Search for 3rd proposal-specific delegation to DIFFERENT delegate, and assert can be found (not deleted)?
     end
   end
 


### PR DESCRIPTION
See issue #125.

### Current status (early days):  
* 2 * failing tests (1 for each case). Test assertions will be more specific when changes fully implemented.  
* Current plan is something like this pseudo-code to modify upsert_delegation/1:  
```
    # Delegations = all delegations for delegator
    #
    #  if trying to create proposal delegation
    #    search Delegations for any global delegation with SAME DELEGATE (should be one or none)    
    #      if find global delegation
    #        return error -> "global delegation already exists"
    #  if trying to create global delegation
    #    search Delegations for any proposal delegations with SAME DELEGATE
    #      if find proposal(s) delegations
    #       delete all proposal delegations found
    #
    #  next (keep the existing functionality):
    #    if trying to create global delegation
    #      search Delegations for ANY GLOBAL delegation
    #        if found (should only be one or none)
    #          update
    #        else
    #          create new delegation 
    #    if trying to create proposal delegation
    #      search Delegations for SAME PROPOSAL delegation
    #        if found (should only be one or none)
    #          update
    #        else
    #          create new delegation
```