### PR TITLE
Linode deploy

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -16,12 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Setup Linode cli
-      uses: brendon1555/setup-linode-cli@master
-      with:
-        LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN }}
-    - run: linode-cli --help
     - name: Deploy
+      with:
+        KUBECONFIG: ${{ secrets.LINODE_KUBE_CONFIG }}
       run: kubectl get pods
 
   # tests:

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -17,11 +17,18 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Deploy
-      uses: steebchen/kubectl@master
       env:
         KUBE_CONFIG_DATA: ${{ secrets.LINODE_KUBE_CONFIG }}
-      with:
-        args: get pods
+      run: |
+        echo "$KUBE_CONFIG_DATA" | base64 --decode > /tmp/config
+        export KUBECONFIG=/tmp/config
+        kubectl rollout restart deployment/api-deployment
+        pod=$(kubectl get pods -l app=api  -o json | jq -r '.items[].metadata.name' | head -1)
+        kubectl wait --timeout=120s --for=condition=Ready pod/$pod
+        kubectl exec -i pod/$pod \
+        --container api-container \
+        -- /opt/app/bin/liquid_voting \
+        eval "LiquidVoting.Release.migrate"
 
   # tests:
   #   name: Tests

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -11,47 +11,60 @@ on:
     - 'CONTRIBUTING.md'
 
 jobs:
-  tests:
-    name: Tests
+  deploy:
+    name: Deploy to GKE
     runs-on: ubuntu-latest
-    container:
-      image: elixir:1.10.2-slim
-    services:
-      postgres:
-        image: postgres:10.4
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: liquid_voting_test
-        ports:
-          - 5432:5432
-        # postgres container doesn't provide a healthcheck
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-    - uses: actions/checkout@v1
-    - name: Install Dependencies
-      run: |
-        mix local.rebar --force
-        mix local.hex --force
-        mix deps.get
-    - name: Run Tests
-      run: mix test
-      env:
-        MIX_ENV: test
-        # refers to the service name, since we're running on containers
-        POSTGRES_HOST: postgres
+    - uses: actions/checkout@master
+    - name: Setup Linode cli
+      uses: brendon1555/setup-linode-cli@master
+      with:
+        LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN }}
+    - run: linode-cli --help
+    - name: Deploy
+      run: kubectl get pods
 
-  linting:
-    name: Linting
-    runs-on: ubuntu-latest
-    container:
-      image: elixir:1.10.2-slim
-    steps:
-    - uses: actions/checkout@v1
-    - name: Install Dependencies
-      run: |
-        mix local.rebar --force
-        mix local.hex --force
-        mix deps.get
-    - name: Run Formatter
-      run: mix format --check-formatted
+  # tests:
+  #   name: Tests
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: elixir:1.10.2-slim
+  #   services:
+  #     postgres:
+  #       image: postgres:10.4
+  #       env:
+  #         POSTGRES_USER: postgres
+  #         POSTGRES_PASSWORD: postgres
+  #         POSTGRES_DB: liquid_voting_test
+  #       ports:
+  #         - 5432:5432
+  #       # postgres container doesn't provide a healthcheck
+  #       options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+  #   steps:
+  #   - uses: actions/checkout@v1
+  #   - name: Install Dependencies
+  #     run: |
+  #       mix local.rebar --force
+  #       mix local.hex --force
+  #       mix deps.get
+  #   - name: Run Tests
+  #     run: mix test
+  #     env:
+  #       MIX_ENV: test
+  #       # refers to the service name, since we're running on containers
+  #       POSTGRES_HOST: postgres
+
+  # linting:
+  #   name: Linting
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: elixir:1.10.2-slim
+  #   steps:
+  #   - uses: actions/checkout@v1
+  #   - name: Install Dependencies
+  #     run: |
+  #       mix local.rebar --force
+  #       mix local.hex --force
+  #       mix deps.get
+  #   - name: Run Formatter
+  #     run: mix format --check-formatted

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -11,66 +11,47 @@ on:
     - 'CONTRIBUTING.md'
 
 jobs:
-  deploy:
-    name: Deploy to Linode
+  tests:
+    name: Tests
     runs-on: ubuntu-latest
+    container:
+      image: elixir:1.10.2-slim
+    services:
+      postgres:
+        image: postgres:10.4
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: liquid_voting_test
+        ports:
+          - 5432:5432
+        # postgres container doesn't provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-    - uses: actions/checkout@master
-    - name: Deploy
-      env:
-        KUBE_CONFIG_DATA: ${{ secrets.LINODE_KUBE_CONFIG }}
+    - uses: actions/checkout@v1
+    - name: Install Dependencies
       run: |
-        echo "$KUBE_CONFIG_DATA" | base64 --decode > /tmp/config
-        export KUBECONFIG=/tmp/config
-        kubectl rollout restart deployment/api-deployment
-        pod=$(kubectl get pods -l app=api  -o json | jq -r '.items[].metadata.name' | head -1)
-        kubectl wait --timeout=120s --for=condition=Ready pod/$pod
-        kubectl exec -i pod/$pod \
-        --container api-container \
-        -- /opt/app/bin/liquid_voting \
-        eval "LiquidVoting.Release.migrate"
+        mix local.rebar --force
+        mix local.hex --force
+        mix deps.get
+    - name: Run Tests
+      run: mix test
+      env:
+        MIX_ENV: test
+        # refers to the service name, since we're running on containers
+        POSTGRES_HOST: postgres
 
-  # tests:
-  #   name: Tests
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: elixir:1.10.2-slim
-  #   services:
-  #     postgres:
-  #       image: postgres:10.4
-  #       env:
-  #         POSTGRES_USER: postgres
-  #         POSTGRES_PASSWORD: postgres
-  #         POSTGRES_DB: liquid_voting_test
-  #       ports:
-  #         - 5432:5432
-  #       # postgres container doesn't provide a healthcheck
-  #       options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-  #   steps:
-  #   - uses: actions/checkout@v1
-  #   - name: Install Dependencies
-  #     run: |
-  #       mix local.rebar --force
-  #       mix local.hex --force
-  #       mix deps.get
-  #   - name: Run Tests
-  #     run: mix test
-  #     env:
-  #       MIX_ENV: test
-  #       # refers to the service name, since we're running on containers
-  #       POSTGRES_HOST: postgres
-
-  # linting:
-  #   name: Linting
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: elixir:1.10.2-slim
-  #   steps:
-  #   - uses: actions/checkout@v1
-  #   - name: Install Dependencies
-  #     run: |
-  #       mix local.rebar --force
-  #       mix local.hex --force
-  #       mix deps.get
-  #   - name: Run Formatter
-  #     run: mix format --check-formatted
+  linting:
+    name: Linting
+    runs-on: ubuntu-latest
+    container:
+      image: elixir:1.10.2-slim
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install Dependencies
+      run: |
+        mix local.rebar --force
+        mix local.hex --force
+        mix deps.get
+    - name: Run Formatter
+      run: mix format --check-formatted

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -12,17 +12,14 @@ on:
 
 jobs:
   deploy:
-    name: Deploy to GKE
+    name: Deploy to Linode
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Setup Linode cli
-      uses: brendon1555/setup-linode-cli@master
-      with:
-        LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN }}
-    - run: linode-cli --help
     - name: Deploy
-      run: kubectl get pods
+      env:
+        LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
+      run: kubectl --token=$LINODE_TOKEN get pods
 
   # tests:
   #   name: Tests

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -17,9 +17,11 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Deploy
+      uses: steebchen/kubectl@master
+      env:
+        KUBE_CONFIG_DATA: ${{ secrets.LINODE_KUBE_CONFIG }}
       with:
-        KUBECONFIG: ${{ secrets.LINODE_KUBE_CONFIG }}
-      run: kubectl get pods
+        args: get pods
 
   # tests:
   #   name: Tests

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -16,10 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+    - name: Setup Linode cli
+      uses: brendon1555/setup-linode-cli@master
+      with:
+        LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN }}
+    - run: linode-cli --help
     - name: Deploy
-      env:
-        LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
-      run: kubectl --token=$LINODE_TOKEN get pods
+      run: kubectl get pods
 
   # tests:
   #   name: Tests

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -80,24 +80,17 @@ jobs:
         docker push $IMAGE_NAME
 
   deploy:
-    name: Deploy to GKE
+    name: Deploy to Linode
     needs: [build-publish]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Login to gcloud
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
-      with:
-        version: '270.0.0'
-        service_account_email: ${{ secrets.GKE_EMAIL }}
-        service_account_key: ${{ secrets.GKE_KEY }}
     - name: Deploy
       env:
-        GKE_CLUSTER: ${{ secrets.GKE_CLUSTER }}
-        GKE_ZONE: ${{ secrets.GKE_ZONE }}
-        GKE_PROJECT: ${{ secrets.GKE_PROJECT }}
+        KUBE_CONFIG_DATA: ${{ secrets.LINODE_KUBE_CONFIG }}
       run: |
-        gcloud container clusters get-credentials $GKE_CLUSTER --zone $GKE_ZONE --project $GKE_PROJECT
+        echo "$KUBE_CONFIG_DATA" | base64 --decode > /tmp/config
+        export KUBECONFIG=/tmp/config
         kubectl rollout restart deployment/api-deployment
         pod=$(kubectl get pods -l app=api  -o json | jq -r '.items[].metadata.name' | head -1)
         kubectl wait --timeout=120s --for=condition=Ready pod/$pod

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -116,21 +116,13 @@ jobs:
         TEST_API_AUTH_KEY: ${{ secrets.TEST_API_AUTH_KEY }}
       with:
         filename: deployment/smoke_tests/smoke_tests.js
-    - name: Login to gcloud
-      if: always()
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
-      with:
-        version: '270.0.0'
-        service_account_email: ${{ secrets.GKE_EMAIL }}
-        service_account_key: ${{ secrets.GKE_KEY }}
     - name: Teardown smoke test data
       if: always()
       env:
-        GKE_CLUSTER: ${{ secrets.GKE_CLUSTER }}
-        GKE_ZONE: ${{ secrets.GKE_ZONE }}
-        GKE_PROJECT: ${{ secrets.GKE_PROJECT }}
+        KUBE_CONFIG_DATA: ${{ secrets.LINODE_KUBE_CONFIG }}
       run: |
-        gcloud container clusters get-credentials $GKE_CLUSTER --zone $GKE_ZONE --project $GKE_PROJECT
+        echo "$KUBE_CONFIG_DATA" | base64 --decode > /tmp/config
+        export KUBECONFIG=/tmp/config
         pod=$(kubectl get pods -l app=api  -o json | jq -r '.items[].metadata.name' | head -1)
         kubectl wait --timeout=120s --for=condition=Ready pod/$pod
         kubectl exec -i pod/$pod \


### PR DESCRIPTION
Updates the deployment and smoke test jobs on pushes to use the Linode cluster.

It removes the intermediate gcloud auth step, and just passes Linode's kubeconfig in through a Github secret.

After merging all new deploys will be made to Linode and not to Google. So if the api.liquidvoting.io domain isn't resolving to the new IP yet, we won't be able to see the changes. So merging needs to be coordinated with domain migration (see https://github.com/liquidvotingio/deployment/issues/10)

Part of https://github.com/liquidvotingio/deployment/issues/35

