### PR TITLE
Update elixir images on Dockerfile and CI

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -15,7 +15,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     container:
-      image: elixir:1.10.2-slim
+      image: elixir:1.11.3-slim
     services:
       postgres:
         image: postgres:10.4
@@ -45,7 +45,7 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     container:
-      image: elixir:1.10.2-slim
+      image: elixir:1.11.3-slim
     steps:
     - uses: actions/checkout@v1
     - name: Install Dependencies

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -15,7 +15,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     container:
-      image: elixir:1.10.2-slim
+      image: elixir:1.11.3-slim
     services:
       postgres:
         image: postgres:10.4
@@ -45,7 +45,7 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     container:
-      image: elixir:1.10.2-slim
+      image: elixir:1.11.3-slim
     steps:
     - uses: actions/checkout@v1
     - name: Install Dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM bitwalker/alpine-elixir:1.10.2 AS release-builder
+FROM bitwalker/alpine-elixir:1.11.0 AS release-builder
 
 # Important!  Update this no-op ENV variable when this Dockerfile
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2020-04-07
+ENV REFRESHED_AT=2021-01-20
 
 # Install NPM
 RUN \


### PR DESCRIPTION
The [build is breaking on the latest dependabot PR merges](https://github.com/liquidvotingio/api/runs/1736752739?check_suite_focus=true), and it turns out that updating the elixir images on the Dockerfile fixes that. This PR then updates it there and on the CI steps