### PR TITLE
Add opentelemetry

### DIFF
--- a/lib/liquid_voting/voting.ex
+++ b/lib/liquid_voting/voting.ex
@@ -61,14 +61,21 @@ defmodule LiquidVoting.Voting do
 
   """
   def list_votes(organization_id) do
-    Tracer.with_span "operation" do
-      Tracer.set_attributes([{:a_key, "a_value"}])
-    end
+    Tracer.with_span "LV/voting" do
+      Tracer.set_attributes([{:action, "list_votes"}, {:organization_id, organization_id}])
+
+    # This just adds a second to process and outputs elapsed time
+    # start = :os.system_time(:seconds)
+    # Process.sleep(1000)
+    # endt = :os.system_time(:seconds)
+    # IO.puts("slept for: #{endt - start} seconds")
 
     Vote
     |> where(organization_id: ^organization_id)
     |> Repo.all()
     |> Repo.preload([:participant])
+
+    end
   end
 
   @doc """

--- a/lib/liquid_voting/voting.ex
+++ b/lib/liquid_voting/voting.ex
@@ -24,10 +24,6 @@ defmodule LiquidVoting.Voting do
 
   """
   def create_vote(attrs \\ %{}) do
-    Tracer.with_span "operation" do
-      Tracer.set_attributes([{:a_key, "a_value"}])
-    end
-
     Repo.transaction(fn ->
       # TODO: refactor case statements into small functions.
 
@@ -65,6 +61,10 @@ defmodule LiquidVoting.Voting do
 
   """
   def list_votes(organization_id) do
+    Tracer.with_span "operation" do
+      Tracer.set_attributes([{:a_key, "a_value"}])
+    end
+
     Vote
     |> where(organization_id: ^organization_id)
     |> Repo.all()

--- a/lib/liquid_voting/voting.ex
+++ b/lib/liquid_voting/voting.ex
@@ -64,17 +64,10 @@ defmodule LiquidVoting.Voting do
     Tracer.with_span "LV/voting" do
       Tracer.set_attributes([{:action, "list_votes"}, {:organization_id, organization_id}])
 
-    # This just adds a second to process and outputs elapsed time
-    # start = :os.system_time(:seconds)
-    # Process.sleep(1000)
-    # endt = :os.system_time(:seconds)
-    # IO.puts("slept for: #{endt - start} seconds")
-
-    Vote
-    |> where(organization_id: ^organization_id)
-    |> Repo.all()
-    |> Repo.preload([:participant])
-
+      Vote
+      |> where(organization_id: ^organization_id)
+      |> Repo.all()
+      |> Repo.preload([:participant])
     end
   end
 


### PR DESCRIPTION
No great breakthough, but let's keep this for now, as it
successfully sends related spans from core api action and
resolver action (list_votes/1 / votes/3).

Also reports related variable value (organization_id). We may not need
this, but demonstrates we can do this kind of thing.