### PR TITLE
Add Phoenix :request_id to our test traces.

### DIFF
--- a/lib/liquid_voting/voting.ex
+++ b/lib/liquid_voting/voting.ex
@@ -62,7 +62,11 @@ defmodule LiquidVoting.Voting do
   """
   def list_votes(organization_id) do
     Tracer.with_span "LV/voting" do
-      Tracer.set_attributes([{:action, "list_votes"}, {:organization_id, organization_id}])
+      Tracer.set_attributes([
+        {:action, "list_votes"},
+        {:request_id, Logger.metadata()[:request_id]},
+        {:organization_id, organization_id}
+      ])
 
       Vote
       |> where(organization_id: ^organization_id)

--- a/lib/liquid_voting_web/resolvers/voting.ex
+++ b/lib/liquid_voting_web/resolvers/voting.ex
@@ -29,7 +29,11 @@ defmodule LiquidVotingWeb.Resolvers.Voting do
 
   def votes(_, _, %{context: %{organization_id: organization_id}}) do
     Tracer.with_span "resolvers/voting" do
-      Tracer.set_attributes([{:action, "votes"}, {:organization_id, organization_id}])
+      Tracer.set_attributes([
+        {:action, "votes"},
+        {:request_id, Logger.metadata()[:request_id]},
+        {:organization_id, organization_id}
+      ])
 
       {:ok, Voting.list_votes(organization_id)}
     end


### PR DESCRIPTION
Currently we are only creating traces on Honeycomb for the
list_votes/1 def and the related resolver votes/3 def (and
only for one form of the latter).