### PR TITLE
Bugfix: Preload voting_method when create vote for delegator.

### DIFF
--- a/lib/liquid_voting/voting.ex
+++ b/lib/liquid_voting/voting.ex
@@ -50,8 +50,12 @@ defmodule LiquidVoting.Voting do
                    organization_id: attrs[:organization_id]
                  ) do
               case Delegations.delete_delegation(delegation) do
-                {:ok, _delegation} -> vote
-                {:error, changeset} -> Repo.rollback(changeset)
+                {:ok, _delegation} ->
+                  vote
+                  |> Repo.preload([:voting_method])
+
+                {:error, changeset} ->
+                  Repo.rollback(changeset)
               end
             else
               vote

--- a/test/liquid_voting_web/absinthe/mutations/create_delegation/before_creating_related_votes_test.exs
+++ b/test/liquid_voting_web/absinthe/mutations/create_delegation/before_creating_related_votes_test.exs
@@ -1,0 +1,94 @@
+defmodule LiquidVotingWeb.Absinthe.Mutations.CreateDelegation.BeforeCreatingRelatedVotesTest do
+  use LiquidVotingWeb.ConnCase
+  import LiquidVoting.Factory
+
+  alias LiquidVotingWeb.Schema.Schema
+
+  describe "create proposal-specific delegation" do
+    test "before creating related vote for delegator" do
+      organization_id = Ecto.UUID.generate()
+      voting_method = insert(:voting_method, organization_id: organization_id)
+
+      delegation =
+        insert(:delegation_for_proposal,
+          voting_method: voting_method,
+          organization_id: organization_id
+        )
+
+      # Create vote by delegator and get details in queries.
+      query = """
+      mutation {
+        createVote(participantEmail: "#{delegation.delegator.email}", votingMethod: "#{
+        voting_method.name
+      }", proposalUrl: "#{delegation.proposal_url}", yes: true) {
+          proposalUrl
+          participant {
+            email
+          }
+          yes
+          votingResult {
+            inFavor
+            against
+          }
+          votingMethod {
+            name
+          }
+        }
+      }
+      """
+
+      {:ok, %{data: %{"createVote" => vote}}} =
+        Absinthe.run(query, Schema, context: %{organization_id: organization_id})
+
+      assert vote["proposalUrl"] == delegation.proposal_url
+      assert vote["participant"]["email"] == delegation.delegator.email
+      assert vote["yes"] == true
+      assert vote["votingResult"]["inFavor"] == 1
+      assert vote["votingResult"]["against"] == 0
+      assert vote["votingMethod"]["name"] == voting_method.name
+    end
+
+    test "before creating related vote for delegate" do
+      organization_id = Ecto.UUID.generate()
+      voting_method = insert(:voting_method, organization_id: organization_id)
+
+      delegation =
+        insert(:delegation_for_proposal,
+          voting_method: voting_method,
+          organization_id: organization_id
+        )
+
+      # Create vote by delegator and get details in queries.
+      query = """
+      mutation {
+        createVote(participantEmail: "#{delegation.delegate.email}", votingMethod: "#{
+        voting_method.name
+      }", proposalUrl: "#{delegation.proposal_url}", yes: true) {
+          proposalUrl
+          participant {
+            email
+          }
+          yes
+          votingResult {
+            inFavor
+            against
+          }
+          votingMethod {
+            name
+          }
+        }
+      }
+      """
+
+      {:ok, %{data: %{"createVote" => vote}}} =
+        Absinthe.run(query, Schema, context: %{organization_id: organization_id})
+
+      assert vote["proposalUrl"] == delegation.proposal_url
+      assert vote["participant"]["email"] == delegation.delegate.email
+      assert vote["yes"] == true
+      assert vote["votingResult"]["inFavor"] == 2
+      assert vote["votingResult"]["against"] == 0
+      assert vote["votingMethod"]["name"] == voting_method.name
+    end
+  end
+end


### PR DESCRIPTION
This fixes case where a voter is already the _delegator_ in a delegation for the same proposal (`proposal_url` + `voting_method`).

Prior to this fix, the process of searching for, and deleting the related delegation, in `create_vote/1` in `voting.ex`, returned a vote without the associated `voting_method` being preloaded, which would cause a `createVote` mutation to fail due to the associated `voting_method` being unavailable.

Adds a preload of `voting_method` when the vote is returned in this case.

Also adds a test of the case that highlighted this bug + a similar test of creating a vote for the _delegate_, following a proposal-delegation creation.